### PR TITLE
Fix links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ The following configuration points are available:
 
 ## Reference
 
-For further information, please visit [the GitHub provider docs](https://www.pulumi.com/docs/intro/cloud-providers/github) or for detailed reference documentation, please visit [the API docs](https://www.pulumi.com/docs/reference/pkg/github).
+For further information, please visit [the MongoDB Atlas provider docs](https://www.pulumi.com/docs/intro/cloud-providers/mongodbatlas) or for detailed reference documentation, please visit [the API docs](https://www.pulumi.com/docs/reference/pkg/mongodbatlas).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -54,4 +54,4 @@ The following configuration points are available:
 
 ## Reference
 
-For further information, please visit [the GitHub provider docs](https://www.pulumi.com/docs/intro/cloud-providers/github) or for detailed reference documentation, please visit [the API docs](https://www.pulumi.com/docs/reference/pkg/github).
+For further information, please visit [the MongoDB Atlas provider docs](https://www.pulumi.com/docs/intro/cloud-providers/mongodbatlas) or for detailed reference documentation, please visit [the API docs](https://www.pulumi.com/docs/reference/pkg/mongodbatlas).


### PR DESCRIPTION
The documentation links were for the GitHub provider, so I corrected the links to point to the pages for the MongoDB Atlas provider.