### PR TITLE
Ensure SDK is correctly being marked as v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Ensure SDK is being marked as v2 correctly
 
 ---
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-mongodbatlas/sdk
+module github.com/pulumi/pulumi-mongodbatlas/sdk/v2
 
 go 1.16
 


### PR DESCRIPTION
Fixes: #75

The changelog and the provider was marked as V2 including the docs but
the sdk wasn't - this rectifies this