### PR TITLE
Fix 'Invalid Addres to set' error

### DIFF
--- a/provider/cmd/pulumi-resource-mongodbatlas/schema.json
+++ b/provider/cmd/pulumi-resource-mongodbatlas/schema.json
@@ -420,6 +420,14 @@
                         }
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "numShards": {
                     "type": "integer",
                     "description": "Provide this value if you set a `cluster_type` of SHARDED or GEOSHARDED. Omit this value if you selected a `cluster_type` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `num_shards` value of 1 and a `cluster_type` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.\n",
@@ -459,6 +467,7 @@
                 "nodejs": {
                     "requiredOutputs": [
                         "containerId",
+                        "id",
                         "regionConfigs"
                     ]
                 }
@@ -1136,6 +1145,14 @@
                         }
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "retentionUnit": {
                     "type": "string",
                     "description": "Scope of the backup policy item: days, weeks, or months.\n",
@@ -1166,6 +1183,7 @@
                     "requiredOutputs": [
                         "frequencyInterval",
                         "frequencyType",
+                        "id",
                         "retentionUnit",
                         "retentionValue"
                     ]
@@ -1257,6 +1275,14 @@
                         }
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "retentionUnit": {
                     "type": "string",
                     "description": "Scope of the backup policy item: days, weeks, or months.\n",
@@ -1287,6 +1313,7 @@
                     "requiredOutputs": [
                         "frequencyInterval",
                         "frequencyType",
+                        "id",
                         "retentionUnit",
                         "retentionValue"
                     ]
@@ -1313,6 +1340,14 @@
                         }
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "retentionUnit": {
                     "type": "string",
                     "description": "Scope of the backup policy item: days, weeks, or months.\n",
@@ -1343,6 +1378,7 @@
                     "requiredOutputs": [
                         "frequencyInterval",
                         "frequencyType",
+                        "id",
                         "retentionUnit",
                         "retentionValue"
                     ]
@@ -1420,6 +1456,15 @@
                         }
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifier for the sharded cluster snapshot.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "replicaSetName": {
                     "type": "string",
                     "description": "Label given to a shard or config server from which Atlas took this snapshot.\n",
@@ -1435,6 +1480,7 @@
                 "nodejs": {
                     "requiredOutputs": [
                         "cloudProvider",
+                        "id",
                         "replicaSetName"
                     ]
                 }
@@ -1630,6 +1676,14 @@
         },
         "mongodbatlas:index/CloudProviderSnapshotBackupPolicyPolicy:CloudProviderSnapshotBackupPolicyPolicy": {
             "properties": {
+                "id": {
+                    "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "policyItems": {
                     "type": "array",
                     "items": {
@@ -1644,6 +1698,7 @@
             },
             "type": "object",
             "required": [
+                "id",
                 "policyItems"
             ]
         },
@@ -1658,6 +1713,14 @@
                     }
                 },
                 "frequencyType": {
+                    "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "id": {
                     "type": "string",
                     "language": {
                         "python": {
@@ -1686,6 +1749,7 @@
             "required": [
                 "frequencyInterval",
                 "frequencyType",
+                "id",
                 "retentionUnit",
                 "retentionValue"
             ]
@@ -2313,6 +2377,15 @@
         },
         "mongodbatlas:index/ClusterSnapshotBackupPolicyPolicy:ClusterSnapshotBackupPolicyPolicy": {
             "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifer of the replication document for a zone in a Global Cluster.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "policyItems": {
                     "type": "array",
                     "items": {
@@ -2329,6 +2402,7 @@
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
+                        "id",
                         "policyItems"
                     ]
                 }
@@ -2346,6 +2420,15 @@
                 },
                 "frequencyType": {
                     "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifer of the replication document for a zone in a Global Cluster.\n",
                     "language": {
                         "python": {
                             "mapCase": false
@@ -2375,6 +2458,7 @@
                     "requiredOutputs": [
                         "frequencyInterval",
                         "frequencyType",
+                        "id",
                         "retentionUnit",
                         "retentionValue"
                     ]
@@ -3631,6 +3715,14 @@
                         }
                     }
                 },
+                "id": {
+                    "type": "integer",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "notAfter": {
                     "type": "string",
                     "language": {
@@ -3654,6 +3746,7 @@
                     "requiredOutputs": [
                         "createdAt",
                         "groupId",
+                        "id",
                         "notAfter",
                         "subject"
                     ]
@@ -7803,6 +7896,15 @@
         },
         "mongodbatlas:index/getClusterSnapshotBackupPolicyPolicy:getClusterSnapshotBackupPolicyPolicy": {
             "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifer of the replication document for a zone in a Global Cluster.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "policyItems": {
                     "type": "array",
                     "items": {
@@ -7817,6 +7919,7 @@
             },
             "type": "object",
             "required": [
+                "id",
                 "policyItems"
             ],
             "language": {
@@ -7837,6 +7940,15 @@
                 },
                 "frequencyType": {
                     "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifer of the replication document for a zone in a Global Cluster.\n",
                     "language": {
                         "python": {
                             "mapCase": false
@@ -7864,6 +7976,7 @@
             "required": [
                 "frequencyInterval",
                 "frequencyType",
+                "id",
                 "retentionUnit",
                 "retentionValue"
             ],
@@ -8843,6 +8956,15 @@
         },
         "mongodbatlas:index/getClustersResultSnapshotBackupPolicyPolicy:getClustersResultSnapshotBackupPolicyPolicy": {
             "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifer of the replication document for a zone in a Global Cluster.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
                 "policyItems": {
                     "type": "array",
                     "items": {
@@ -8857,6 +8979,7 @@
             },
             "type": "object",
             "required": [
+                "id",
                 "policyItems"
             ],
             "language": {
@@ -8877,6 +9000,15 @@
                 },
                 "frequencyType": {
                     "type": "string",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifer of the replication document for a zone in a Global Cluster.\n",
                     "language": {
                         "python": {
                             "mapCase": false
@@ -8904,6 +9036,7 @@
             "required": [
                 "frequencyInterval",
                 "frequencyType",
+                "id",
                 "retentionUnit",
                 "retentionValue"
             ],

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,11 +4,11 @@ go 1.18
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9
-	github.com/mongodb/terraform-provider-mongodbatlas => github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20220907111040-c32757419caa
+	github.com/mongodb/terraform-provider-mongodbatlas => github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20220913182439-ec2193ad4fbb
 )
 
 require (
-	github.com/mongodb/terraform-provider-mongodbatlas v1.4.1
+	github.com/mongodb/terraform-provider-mongodbatlas v1.4.5
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.30.0
 	github.com/pulumi/pulumi/sdk/v3 v3.39.1
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -808,8 +808,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9 h1:JMw+t5I+6E8Lna7JF+ghAoOLOl23UIbshJyRNP+K1HU=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9/go.mod h1:mYPs/uchNcBq7AclQv9QUtSf9iNcfp1Ag21jqTlDf2M=
-github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20220907111040-c32757419caa h1:B6sNTls36MEJBUh2okj/kcytbW2gSDKXisZmCxA57cg=
-github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20220907111040-c32757419caa/go.mod h1:VYSVlO3O96gQ/d/jVgCqfaF1lAuSt1k0KPSh7JJ+zVU=
+github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20220913182439-ec2193ad4fbb h1:wKsZtj7haNfYMeggB09mUE7cRzpPmNsPY2e2mzwTUc8=
+github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20220913182439-ec2193ad4fbb/go.mod h1:VYSVlO3O96gQ/d/jVgCqfaF1lAuSt1k0KPSh7JJ+zVU=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/sdk/dotnet/Inputs/AdvancedClusterReplicationSpecArgs.cs
+++ b/sdk/dotnet/Inputs/AdvancedClusterReplicationSpecArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
             set => _containerId = value;
         }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Provide this value if you set a `cluster_type` of SHARDED or GEOSHARDED. Omit this value if you selected a `cluster_type` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `num_shards` value of 1 and a `cluster_type` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
         /// </summary>

--- a/sdk/dotnet/Inputs/AdvancedClusterReplicationSpecGetArgs.cs
+++ b/sdk/dotnet/Inputs/AdvancedClusterReplicationSpecGetArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
             set => _containerId = value;
         }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Provide this value if you set a `cluster_type` of SHARDED or GEOSHARDED. Omit this value if you selected a `cluster_type` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `num_shards` value of 1 and a `cluster_type` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
         /// </summary>

--- a/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemDailyArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemDailyArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>

--- a/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemDailyGetArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemDailyGetArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>

--- a/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemMonthlyArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemMonthlyArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>

--- a/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemMonthlyGetArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemMonthlyGetArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>

--- a/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemWeeklyArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemWeeklyArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>

--- a/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemWeeklyGetArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSchedulePolicyItemWeeklyGetArgs.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>

--- a/sdk/dotnet/Inputs/CloudBackupSnapshotMemberArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSnapshotMemberArgs.cs
@@ -19,6 +19,12 @@ namespace Pulumi.Mongodbatlas.Inputs
         public Input<string>? CloudProvider { get; set; }
 
         /// <summary>
+        /// Unique identifier for the sharded cluster snapshot.
+        /// </summary>
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
+        /// <summary>
         /// Label given to a shard or config server from which Atlas took this snapshot.
         /// </summary>
         [Input("replicaSetName")]

--- a/sdk/dotnet/Inputs/CloudBackupSnapshotMemberGetArgs.cs
+++ b/sdk/dotnet/Inputs/CloudBackupSnapshotMemberGetArgs.cs
@@ -19,6 +19,12 @@ namespace Pulumi.Mongodbatlas.Inputs
         public Input<string>? CloudProvider { get; set; }
 
         /// <summary>
+        /// Unique identifier for the sharded cluster snapshot.
+        /// </summary>
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
+        /// <summary>
         /// Label given to a shard or config server from which Atlas took this snapshot.
         /// </summary>
         [Input("replicaSetName")]

--- a/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyArgs.cs
+++ b/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyArgs.cs
@@ -12,6 +12,9 @@ namespace Pulumi.Mongodbatlas.Inputs
 
     public sealed class CloudProviderSnapshotBackupPolicyPolicyArgs : global::Pulumi.ResourceArgs
     {
+        [Input("id", required: true)]
+        public Input<string> Id { get; set; } = null!;
+
         [Input("policyItems", required: true)]
         private InputList<Inputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs>? _policyItems;
         public InputList<Inputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs> PolicyItems

--- a/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyGetArgs.cs
+++ b/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyGetArgs.cs
@@ -12,6 +12,9 @@ namespace Pulumi.Mongodbatlas.Inputs
 
     public sealed class CloudProviderSnapshotBackupPolicyPolicyGetArgs : global::Pulumi.ResourceArgs
     {
+        [Input("id", required: true)]
+        public Input<string> Id { get; set; } = null!;
+
         [Input("policyItems", required: true)]
         private InputList<Inputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItemGetArgs>? _policyItems;
         public InputList<Inputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItemGetArgs> PolicyItems

--- a/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs.cs
+++ b/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs.cs
@@ -18,6 +18,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType", required: true)]
         public Input<string> FrequencyType { get; set; } = null!;
 
+        [Input("id", required: true)]
+        public Input<string> Id { get; set; } = null!;
+
         [Input("retentionUnit", required: true)]
         public Input<string> RetentionUnit { get; set; } = null!;
 

--- a/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItemGetArgs.cs
+++ b/sdk/dotnet/Inputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItemGetArgs.cs
@@ -18,6 +18,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType", required: true)]
         public Input<string> FrequencyType { get; set; } = null!;
 
+        [Input("id", required: true)]
+        public Input<string> Id { get; set; } = null!;
+
         [Input("retentionUnit", required: true)]
         public Input<string> RetentionUnit { get; set; } = null!;
 

--- a/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyArgs.cs
@@ -12,6 +12,12 @@ namespace Pulumi.Mongodbatlas.Inputs
 
     public sealed class ClusterSnapshotBackupPolicyPolicyArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         [Input("policyItems")]
         private InputList<Inputs.ClusterSnapshotBackupPolicyPolicyPolicyItemArgs>? _policyItems;
         public InputList<Inputs.ClusterSnapshotBackupPolicyPolicyPolicyItemArgs> PolicyItems

--- a/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyGetArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyGetArgs.cs
@@ -12,6 +12,12 @@ namespace Pulumi.Mongodbatlas.Inputs
 
     public sealed class ClusterSnapshotBackupPolicyPolicyGetArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         [Input("policyItems")]
         private InputList<Inputs.ClusterSnapshotBackupPolicyPolicyPolicyItemGetArgs>? _policyItems;
         public InputList<Inputs.ClusterSnapshotBackupPolicyPolicyPolicyItemGetArgs> PolicyItems

--- a/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyPolicyItemArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyPolicyItemArgs.cs
@@ -18,6 +18,12 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         [Input("retentionUnit")]
         public Input<string>? RetentionUnit { get; set; }
 

--- a/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyPolicyItemGetArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterSnapshotBackupPolicyPolicyPolicyItemGetArgs.cs
@@ -18,6 +18,12 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("frequencyType")]
         public Input<string>? FrequencyType { get; set; }
 
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        [Input("id")]
+        public Input<string>? Id { get; set; }
+
         [Input("retentionUnit")]
         public Input<string>? RetentionUnit { get; set; }
 

--- a/sdk/dotnet/Inputs/X509AuthenticationDatabaseUserCertificateArgs.cs
+++ b/sdk/dotnet/Inputs/X509AuthenticationDatabaseUserCertificateArgs.cs
@@ -18,6 +18,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("groupId")]
         public Input<string>? GroupId { get; set; }
 
+        [Input("id")]
+        public Input<int>? Id { get; set; }
+
         [Input("notAfter")]
         public Input<string>? NotAfter { get; set; }
 

--- a/sdk/dotnet/Inputs/X509AuthenticationDatabaseUserCertificateGetArgs.cs
+++ b/sdk/dotnet/Inputs/X509AuthenticationDatabaseUserCertificateGetArgs.cs
@@ -18,6 +18,9 @@ namespace Pulumi.Mongodbatlas.Inputs
         [Input("groupId")]
         public Input<string>? GroupId { get; set; }
 
+        [Input("id")]
+        public Input<int>? Id { get; set; }
+
         [Input("notAfter")]
         public Input<string>? NotAfter { get; set; }
 

--- a/sdk/dotnet/Outputs/AdvancedClusterReplicationSpec.cs
+++ b/sdk/dotnet/Outputs/AdvancedClusterReplicationSpec.cs
@@ -17,6 +17,7 @@ namespace Pulumi.Mongodbatlas.Outputs
         /// A key-value map of the Network Peering Container ID(s) for the configuration specified in `region_configs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.  The syntax is `"providerName:regionName" = "containerId"`. Example `AWS:US_EAST_1" = "61e0797dde08fb498ca11a71`.
         /// </summary>
         public readonly ImmutableDictionary<string, string>? ContainerId;
+        public readonly string? Id;
         /// <summary>
         /// Provide this value if you set a `cluster_type` of SHARDED or GEOSHARDED. Omit this value if you selected a `cluster_type` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `num_shards` value of 1 and a `cluster_type` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
         /// </summary>
@@ -34,6 +35,8 @@ namespace Pulumi.Mongodbatlas.Outputs
         private AdvancedClusterReplicationSpec(
             ImmutableDictionary<string, string>? containerId,
 
+            string? id,
+
             int? numShards,
 
             ImmutableArray<Outputs.AdvancedClusterReplicationSpecRegionConfig> regionConfigs,
@@ -41,6 +44,7 @@ namespace Pulumi.Mongodbatlas.Outputs
             string? zoneName)
         {
             ContainerId = containerId;
+            Id = id;
             NumShards = numShards;
             RegionConfigs = regionConfigs;
             ZoneName = zoneName;

--- a/sdk/dotnet/Outputs/CloudBackupSchedulePolicyItemDaily.cs
+++ b/sdk/dotnet/Outputs/CloudBackupSchedulePolicyItemDaily.cs
@@ -21,6 +21,7 @@ namespace Pulumi.Mongodbatlas.Outputs
         /// Frequency associated with the export snapshot item.
         /// </summary>
         public readonly string? FrequencyType;
+        public readonly string? Id;
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>
@@ -36,12 +37,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string? frequencyType,
 
+            string? id,
+
             string retentionUnit,
 
             int retentionValue)
         {
             FrequencyInterval = frequencyInterval;
             FrequencyType = frequencyType;
+            Id = id;
             RetentionUnit = retentionUnit;
             RetentionValue = retentionValue;
         }

--- a/sdk/dotnet/Outputs/CloudBackupSchedulePolicyItemMonthly.cs
+++ b/sdk/dotnet/Outputs/CloudBackupSchedulePolicyItemMonthly.cs
@@ -21,6 +21,7 @@ namespace Pulumi.Mongodbatlas.Outputs
         /// Frequency associated with the export snapshot item.
         /// </summary>
         public readonly string? FrequencyType;
+        public readonly string? Id;
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>
@@ -36,12 +37,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string? frequencyType,
 
+            string? id,
+
             string retentionUnit,
 
             int retentionValue)
         {
             FrequencyInterval = frequencyInterval;
             FrequencyType = frequencyType;
+            Id = id;
             RetentionUnit = retentionUnit;
             RetentionValue = retentionValue;
         }

--- a/sdk/dotnet/Outputs/CloudBackupSchedulePolicyItemWeekly.cs
+++ b/sdk/dotnet/Outputs/CloudBackupSchedulePolicyItemWeekly.cs
@@ -21,6 +21,7 @@ namespace Pulumi.Mongodbatlas.Outputs
         /// Frequency associated with the export snapshot item.
         /// </summary>
         public readonly string? FrequencyType;
+        public readonly string? Id;
         /// <summary>
         /// Scope of the backup policy item: days, weeks, or months.
         /// </summary>
@@ -36,12 +37,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string? frequencyType,
 
+            string? id,
+
             string retentionUnit,
 
             int retentionValue)
         {
             FrequencyInterval = frequencyInterval;
             FrequencyType = frequencyType;
+            Id = id;
             RetentionUnit = retentionUnit;
             RetentionValue = retentionValue;
         }

--- a/sdk/dotnet/Outputs/CloudBackupSnapshotMember.cs
+++ b/sdk/dotnet/Outputs/CloudBackupSnapshotMember.cs
@@ -18,6 +18,10 @@ namespace Pulumi.Mongodbatlas.Outputs
         /// </summary>
         public readonly string? CloudProvider;
         /// <summary>
+        /// Unique identifier for the sharded cluster snapshot.
+        /// </summary>
+        public readonly string? Id;
+        /// <summary>
         /// Label given to a shard or config server from which Atlas took this snapshot.
         /// </summary>
         public readonly string? ReplicaSetName;
@@ -26,9 +30,12 @@ namespace Pulumi.Mongodbatlas.Outputs
         private CloudBackupSnapshotMember(
             string? cloudProvider,
 
+            string? id,
+
             string? replicaSetName)
         {
             CloudProvider = cloudProvider;
+            Id = id;
             ReplicaSetName = replicaSetName;
         }
     }

--- a/sdk/dotnet/Outputs/CloudProviderSnapshotBackupPolicyPolicy.cs
+++ b/sdk/dotnet/Outputs/CloudProviderSnapshotBackupPolicyPolicy.cs
@@ -13,11 +13,16 @@ namespace Pulumi.Mongodbatlas.Outputs
     [OutputType]
     public sealed class CloudProviderSnapshotBackupPolicyPolicy
     {
+        public readonly string Id;
         public readonly ImmutableArray<Outputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItem> PolicyItems;
 
         [OutputConstructor]
-        private CloudProviderSnapshotBackupPolicyPolicy(ImmutableArray<Outputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItem> policyItems)
+        private CloudProviderSnapshotBackupPolicyPolicy(
+            string id,
+
+            ImmutableArray<Outputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItem> policyItems)
         {
+            Id = id;
             PolicyItems = policyItems;
         }
     }

--- a/sdk/dotnet/Outputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItem.cs
+++ b/sdk/dotnet/Outputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItem.cs
@@ -15,6 +15,7 @@ namespace Pulumi.Mongodbatlas.Outputs
     {
         public readonly int FrequencyInterval;
         public readonly string FrequencyType;
+        public readonly string Id;
         public readonly string RetentionUnit;
         public readonly int RetentionValue;
 
@@ -24,12 +25,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string frequencyType,
 
+            string id,
+
             string retentionUnit,
 
             int retentionValue)
         {
             FrequencyInterval = frequencyInterval;
             FrequencyType = frequencyType;
+            Id = id;
             RetentionUnit = retentionUnit;
             RetentionValue = retentionValue;
         }

--- a/sdk/dotnet/Outputs/ClusterSnapshotBackupPolicyPolicy.cs
+++ b/sdk/dotnet/Outputs/ClusterSnapshotBackupPolicyPolicy.cs
@@ -13,11 +13,19 @@ namespace Pulumi.Mongodbatlas.Outputs
     [OutputType]
     public sealed class ClusterSnapshotBackupPolicyPolicy
     {
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        public readonly string? Id;
         public readonly ImmutableArray<Outputs.ClusterSnapshotBackupPolicyPolicyPolicyItem> PolicyItems;
 
         [OutputConstructor]
-        private ClusterSnapshotBackupPolicyPolicy(ImmutableArray<Outputs.ClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems)
+        private ClusterSnapshotBackupPolicyPolicy(
+            string? id,
+
+            ImmutableArray<Outputs.ClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems)
         {
+            Id = id;
             PolicyItems = policyItems;
         }
     }

--- a/sdk/dotnet/Outputs/ClusterSnapshotBackupPolicyPolicyPolicyItem.cs
+++ b/sdk/dotnet/Outputs/ClusterSnapshotBackupPolicyPolicyPolicyItem.cs
@@ -15,6 +15,10 @@ namespace Pulumi.Mongodbatlas.Outputs
     {
         public readonly int? FrequencyInterval;
         public readonly string? FrequencyType;
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        public readonly string? Id;
         public readonly string? RetentionUnit;
         public readonly int? RetentionValue;
 
@@ -24,12 +28,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string? frequencyType,
 
+            string? id,
+
             string? retentionUnit,
 
             int? retentionValue)
         {
             FrequencyInterval = frequencyInterval;
             FrequencyType = frequencyType;
+            Id = id;
             RetentionUnit = retentionUnit;
             RetentionValue = retentionValue;
         }

--- a/sdk/dotnet/Outputs/GetClusterSnapshotBackupPolicyPolicyPolicyItemResult.cs
+++ b/sdk/dotnet/Outputs/GetClusterSnapshotBackupPolicyPolicyPolicyItemResult.cs
@@ -15,6 +15,10 @@ namespace Pulumi.Mongodbatlas.Outputs
     {
         public readonly int FrequencyInterval;
         public readonly string FrequencyType;
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        public readonly string Id;
         public readonly string RetentionUnit;
         public readonly int RetentionValue;
 
@@ -24,12 +28,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string frequencyType,
 
+            string id,
+
             string retentionUnit,
 
             int retentionValue)
         {
             FrequencyInterval = frequencyInterval;
             FrequencyType = frequencyType;
+            Id = id;
             RetentionUnit = retentionUnit;
             RetentionValue = retentionValue;
         }

--- a/sdk/dotnet/Outputs/GetClusterSnapshotBackupPolicyPolicyResult.cs
+++ b/sdk/dotnet/Outputs/GetClusterSnapshotBackupPolicyPolicyResult.cs
@@ -13,11 +13,19 @@ namespace Pulumi.Mongodbatlas.Outputs
     [OutputType]
     public sealed class GetClusterSnapshotBackupPolicyPolicyResult
     {
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        public readonly string Id;
         public readonly ImmutableArray<Outputs.GetClusterSnapshotBackupPolicyPolicyPolicyItemResult> PolicyItems;
 
         [OutputConstructor]
-        private GetClusterSnapshotBackupPolicyPolicyResult(ImmutableArray<Outputs.GetClusterSnapshotBackupPolicyPolicyPolicyItemResult> policyItems)
+        private GetClusterSnapshotBackupPolicyPolicyResult(
+            string id,
+
+            ImmutableArray<Outputs.GetClusterSnapshotBackupPolicyPolicyPolicyItemResult> policyItems)
         {
+            Id = id;
             PolicyItems = policyItems;
         }
     }

--- a/sdk/dotnet/Outputs/GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult.cs
+++ b/sdk/dotnet/Outputs/GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult.cs
@@ -15,6 +15,10 @@ namespace Pulumi.Mongodbatlas.Outputs
     {
         public readonly int FrequencyInterval;
         public readonly string FrequencyType;
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        public readonly string Id;
         public readonly string RetentionUnit;
         public readonly int RetentionValue;
 
@@ -24,12 +28,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string frequencyType,
 
+            string id,
+
             string retentionUnit,
 
             int retentionValue)
         {
             FrequencyInterval = frequencyInterval;
             FrequencyType = frequencyType;
+            Id = id;
             RetentionUnit = retentionUnit;
             RetentionValue = retentionValue;
         }

--- a/sdk/dotnet/Outputs/GetClustersResultSnapshotBackupPolicyPolicyResult.cs
+++ b/sdk/dotnet/Outputs/GetClustersResultSnapshotBackupPolicyPolicyResult.cs
@@ -13,11 +13,19 @@ namespace Pulumi.Mongodbatlas.Outputs
     [OutputType]
     public sealed class GetClustersResultSnapshotBackupPolicyPolicyResult
     {
+        /// <summary>
+        /// Unique identifer of the replication document for a zone in a Global Cluster.
+        /// </summary>
+        public readonly string Id;
         public readonly ImmutableArray<Outputs.GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult> PolicyItems;
 
         [OutputConstructor]
-        private GetClustersResultSnapshotBackupPolicyPolicyResult(ImmutableArray<Outputs.GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult> policyItems)
+        private GetClustersResultSnapshotBackupPolicyPolicyResult(
+            string id,
+
+            ImmutableArray<Outputs.GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult> policyItems)
         {
+            Id = id;
             PolicyItems = policyItems;
         }
     }

--- a/sdk/dotnet/Outputs/X509AuthenticationDatabaseUserCertificate.cs
+++ b/sdk/dotnet/Outputs/X509AuthenticationDatabaseUserCertificate.cs
@@ -15,6 +15,7 @@ namespace Pulumi.Mongodbatlas.Outputs
     {
         public readonly string? CreatedAt;
         public readonly string? GroupId;
+        public readonly int? Id;
         public readonly string? NotAfter;
         public readonly string? Subject;
 
@@ -24,12 +25,15 @@ namespace Pulumi.Mongodbatlas.Outputs
 
             string? groupId,
 
+            int? id,
+
             string? notAfter,
 
             string? subject)
         {
             CreatedAt = createdAt;
             GroupId = groupId;
+            Id = id;
             NotAfter = notAfter;
             Subject = subject;
         }

--- a/sdk/go/mongodbatlas/pulumiTypes.go
+++ b/sdk/go/mongodbatlas/pulumiTypes.go
@@ -940,6 +940,7 @@ func (o AdvancedClusterLabelArrayOutput) Index(i pulumi.IntInput) AdvancedCluste
 type AdvancedClusterReplicationSpec struct {
 	// A key-value map of the Network Peering Container ID(s) for the configuration specified in `regionConfigs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.  The syntax is `"providerName:regionName" = "containerId"`. Example `AWS:US_EAST_1" = "61e0797dde08fb498ca11a71`.
 	ContainerId map[string]string `pulumi:"containerId"`
+	Id          *string           `pulumi:"id"`
 	// Provide this value if you set a `clusterType` of SHARDED or GEOSHARDED. Omit this value if you selected a `clusterType` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `numShards` value of 1 and a `clusterType` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
 	NumShards *int `pulumi:"numShards"`
 	// Configuration for the hardware specifications for nodes set for a given regionEach `regionConfigs` object describes the region's priority in elections and the number and type of MongoDB nodes that Atlas deploys to the region. Each `regionConfigs` object must have either an `analyticsSpecs` object, `electableSpecs` object, or `readOnlySpecs` object. See below
@@ -962,6 +963,7 @@ type AdvancedClusterReplicationSpecInput interface {
 type AdvancedClusterReplicationSpecArgs struct {
 	// A key-value map of the Network Peering Container ID(s) for the configuration specified in `regionConfigs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.  The syntax is `"providerName:regionName" = "containerId"`. Example `AWS:US_EAST_1" = "61e0797dde08fb498ca11a71`.
 	ContainerId pulumi.StringMapInput `pulumi:"containerId"`
+	Id          pulumi.StringPtrInput `pulumi:"id"`
 	// Provide this value if you set a `clusterType` of SHARDED or GEOSHARDED. Omit this value if you selected a `clusterType` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `numShards` value of 1 and a `clusterType` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
 	NumShards pulumi.IntPtrInput `pulumi:"numShards"`
 	// Configuration for the hardware specifications for nodes set for a given regionEach `regionConfigs` object describes the region's priority in elections and the number and type of MongoDB nodes that Atlas deploys to the region. Each `regionConfigs` object must have either an `analyticsSpecs` object, `electableSpecs` object, or `readOnlySpecs` object. See below
@@ -1024,6 +1026,10 @@ func (o AdvancedClusterReplicationSpecOutput) ToAdvancedClusterReplicationSpecOu
 // A key-value map of the Network Peering Container ID(s) for the configuration specified in `regionConfigs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.  The syntax is `"providerName:regionName" = "containerId"`. Example `AWS:US_EAST_1" = "61e0797dde08fb498ca11a71`.
 func (o AdvancedClusterReplicationSpecOutput) ContainerId() pulumi.StringMapOutput {
 	return o.ApplyT(func(v AdvancedClusterReplicationSpec) map[string]string { return v.ContainerId }).(pulumi.StringMapOutput)
+}
+
+func (o AdvancedClusterReplicationSpecOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v AdvancedClusterReplicationSpec) *string { return v.Id }).(pulumi.StringPtrOutput)
 }
 
 // Provide this value if you set a `clusterType` of SHARDED or GEOSHARDED. Omit this value if you selected a `clusterType` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `numShards` value of 1 and a `clusterType` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
@@ -3193,6 +3199,7 @@ type CloudBackupSchedulePolicyItemDaily struct {
 	FrequencyInterval int `pulumi:"frequencyInterval"`
 	// Frequency associated with the export snapshot item.
 	FrequencyType *string `pulumi:"frequencyType"`
+	Id            *string `pulumi:"id"`
 	// Scope of the backup policy item: days, weeks, or months.
 	RetentionUnit string `pulumi:"retentionUnit"`
 	// Value to associate with `retentionUnit`.
@@ -3215,6 +3222,7 @@ type CloudBackupSchedulePolicyItemDailyArgs struct {
 	FrequencyInterval pulumi.IntInput `pulumi:"frequencyInterval"`
 	// Frequency associated with the export snapshot item.
 	FrequencyType pulumi.StringPtrInput `pulumi:"frequencyType"`
+	Id            pulumi.StringPtrInput `pulumi:"id"`
 	// Scope of the backup policy item: days, weeks, or months.
 	RetentionUnit pulumi.StringInput `pulumi:"retentionUnit"`
 	// Value to associate with `retentionUnit`.
@@ -3308,6 +3316,10 @@ func (o CloudBackupSchedulePolicyItemDailyOutput) FrequencyType() pulumi.StringP
 	return o.ApplyT(func(v CloudBackupSchedulePolicyItemDaily) *string { return v.FrequencyType }).(pulumi.StringPtrOutput)
 }
 
+func (o CloudBackupSchedulePolicyItemDailyOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v CloudBackupSchedulePolicyItemDaily) *string { return v.Id }).(pulumi.StringPtrOutput)
+}
+
 // Scope of the backup policy item: days, weeks, or months.
 func (o CloudBackupSchedulePolicyItemDailyOutput) RetentionUnit() pulumi.StringOutput {
 	return o.ApplyT(func(v CloudBackupSchedulePolicyItemDaily) string { return v.RetentionUnit }).(pulumi.StringOutput)
@@ -3359,6 +3371,15 @@ func (o CloudBackupSchedulePolicyItemDailyPtrOutput) FrequencyType() pulumi.Stri
 			return nil
 		}
 		return v.FrequencyType
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o CloudBackupSchedulePolicyItemDailyPtrOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *CloudBackupSchedulePolicyItemDaily) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Id
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3596,6 +3617,7 @@ type CloudBackupSchedulePolicyItemMonthly struct {
 	FrequencyInterval int `pulumi:"frequencyInterval"`
 	// Frequency associated with the export snapshot item.
 	FrequencyType *string `pulumi:"frequencyType"`
+	Id            *string `pulumi:"id"`
 	// Scope of the backup policy item: days, weeks, or months.
 	RetentionUnit string `pulumi:"retentionUnit"`
 	// Value to associate with `retentionUnit`.
@@ -3618,6 +3640,7 @@ type CloudBackupSchedulePolicyItemMonthlyArgs struct {
 	FrequencyInterval pulumi.IntInput `pulumi:"frequencyInterval"`
 	// Frequency associated with the export snapshot item.
 	FrequencyType pulumi.StringPtrInput `pulumi:"frequencyType"`
+	Id            pulumi.StringPtrInput `pulumi:"id"`
 	// Scope of the backup policy item: days, weeks, or months.
 	RetentionUnit pulumi.StringInput `pulumi:"retentionUnit"`
 	// Value to associate with `retentionUnit`.
@@ -3685,6 +3708,10 @@ func (o CloudBackupSchedulePolicyItemMonthlyOutput) FrequencyType() pulumi.Strin
 	return o.ApplyT(func(v CloudBackupSchedulePolicyItemMonthly) *string { return v.FrequencyType }).(pulumi.StringPtrOutput)
 }
 
+func (o CloudBackupSchedulePolicyItemMonthlyOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v CloudBackupSchedulePolicyItemMonthly) *string { return v.Id }).(pulumi.StringPtrOutput)
+}
+
 // Scope of the backup policy item: days, weeks, or months.
 func (o CloudBackupSchedulePolicyItemMonthlyOutput) RetentionUnit() pulumi.StringOutput {
 	return o.ApplyT(func(v CloudBackupSchedulePolicyItemMonthly) string { return v.RetentionUnit }).(pulumi.StringOutput)
@@ -3720,6 +3747,7 @@ type CloudBackupSchedulePolicyItemWeekly struct {
 	FrequencyInterval int `pulumi:"frequencyInterval"`
 	// Frequency associated with the export snapshot item.
 	FrequencyType *string `pulumi:"frequencyType"`
+	Id            *string `pulumi:"id"`
 	// Scope of the backup policy item: days, weeks, or months.
 	RetentionUnit string `pulumi:"retentionUnit"`
 	// Value to associate with `retentionUnit`.
@@ -3742,6 +3770,7 @@ type CloudBackupSchedulePolicyItemWeeklyArgs struct {
 	FrequencyInterval pulumi.IntInput `pulumi:"frequencyInterval"`
 	// Frequency associated with the export snapshot item.
 	FrequencyType pulumi.StringPtrInput `pulumi:"frequencyType"`
+	Id            pulumi.StringPtrInput `pulumi:"id"`
 	// Scope of the backup policy item: days, weeks, or months.
 	RetentionUnit pulumi.StringInput `pulumi:"retentionUnit"`
 	// Value to associate with `retentionUnit`.
@@ -3807,6 +3836,10 @@ func (o CloudBackupSchedulePolicyItemWeeklyOutput) FrequencyInterval() pulumi.In
 // Frequency associated with the export snapshot item.
 func (o CloudBackupSchedulePolicyItemWeeklyOutput) FrequencyType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v CloudBackupSchedulePolicyItemWeekly) *string { return v.FrequencyType }).(pulumi.StringPtrOutput)
+}
+
+func (o CloudBackupSchedulePolicyItemWeeklyOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v CloudBackupSchedulePolicyItemWeekly) *string { return v.Id }).(pulumi.StringPtrOutput)
 }
 
 // Scope of the backup policy item: days, weeks, or months.
@@ -4054,6 +4087,8 @@ func (o CloudBackupSnapshotExportJobCustomDataArrayOutput) Index(i pulumi.IntInp
 type CloudBackupSnapshotMember struct {
 	// Cloud provider that stores this snapshot.
 	CloudProvider *string `pulumi:"cloudProvider"`
+	// Unique identifier for the sharded cluster snapshot.
+	Id *string `pulumi:"id"`
 	// Label given to a shard or config server from which Atlas took this snapshot.
 	ReplicaSetName *string `pulumi:"replicaSetName"`
 }
@@ -4072,6 +4107,8 @@ type CloudBackupSnapshotMemberInput interface {
 type CloudBackupSnapshotMemberArgs struct {
 	// Cloud provider that stores this snapshot.
 	CloudProvider pulumi.StringPtrInput `pulumi:"cloudProvider"`
+	// Unique identifier for the sharded cluster snapshot.
+	Id pulumi.StringPtrInput `pulumi:"id"`
 	// Label given to a shard or config server from which Atlas took this snapshot.
 	ReplicaSetName pulumi.StringPtrInput `pulumi:"replicaSetName"`
 }
@@ -4130,6 +4167,11 @@ func (o CloudBackupSnapshotMemberOutput) ToCloudBackupSnapshotMemberOutputWithCo
 // Cloud provider that stores this snapshot.
 func (o CloudBackupSnapshotMemberOutput) CloudProvider() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v CloudBackupSnapshotMember) *string { return v.CloudProvider }).(pulumi.StringPtrOutput)
+}
+
+// Unique identifier for the sharded cluster snapshot.
+func (o CloudBackupSnapshotMemberOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v CloudBackupSnapshotMember) *string { return v.Id }).(pulumi.StringPtrOutput)
 }
 
 // Label given to a shard or config server from which Atlas took this snapshot.
@@ -4837,6 +4879,7 @@ func (o CloudProviderAccessSetupAwsConfigArrayOutput) Index(i pulumi.IntInput) C
 }
 
 type CloudProviderSnapshotBackupPolicyPolicy struct {
+	Id          string                                              `pulumi:"id"`
 	PolicyItems []CloudProviderSnapshotBackupPolicyPolicyPolicyItem `pulumi:"policyItems"`
 }
 
@@ -4852,6 +4895,7 @@ type CloudProviderSnapshotBackupPolicyPolicyInput interface {
 }
 
 type CloudProviderSnapshotBackupPolicyPolicyArgs struct {
+	Id          pulumi.StringInput                                          `pulumi:"id"`
 	PolicyItems CloudProviderSnapshotBackupPolicyPolicyPolicyItemArrayInput `pulumi:"policyItems"`
 }
 
@@ -4906,6 +4950,10 @@ func (o CloudProviderSnapshotBackupPolicyPolicyOutput) ToCloudProviderSnapshotBa
 	return o
 }
 
+func (o CloudProviderSnapshotBackupPolicyPolicyOutput) Id() pulumi.StringOutput {
+	return o.ApplyT(func(v CloudProviderSnapshotBackupPolicyPolicy) string { return v.Id }).(pulumi.StringOutput)
+}
+
 func (o CloudProviderSnapshotBackupPolicyPolicyOutput) PolicyItems() CloudProviderSnapshotBackupPolicyPolicyPolicyItemArrayOutput {
 	return o.ApplyT(func(v CloudProviderSnapshotBackupPolicyPolicy) []CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
 		return v.PolicyItems
@@ -4935,6 +4983,7 @@ func (o CloudProviderSnapshotBackupPolicyPolicyArrayOutput) Index(i pulumi.IntIn
 type CloudProviderSnapshotBackupPolicyPolicyPolicyItem struct {
 	FrequencyInterval int    `pulumi:"frequencyInterval"`
 	FrequencyType     string `pulumi:"frequencyType"`
+	Id                string `pulumi:"id"`
 	RetentionUnit     string `pulumi:"retentionUnit"`
 	RetentionValue    int    `pulumi:"retentionValue"`
 }
@@ -4953,6 +5002,7 @@ type CloudProviderSnapshotBackupPolicyPolicyPolicyItemInput interface {
 type CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs struct {
 	FrequencyInterval pulumi.IntInput    `pulumi:"frequencyInterval"`
 	FrequencyType     pulumi.StringInput `pulumi:"frequencyType"`
+	Id                pulumi.StringInput `pulumi:"id"`
 	RetentionUnit     pulumi.StringInput `pulumi:"retentionUnit"`
 	RetentionValue    pulumi.IntInput    `pulumi:"retentionValue"`
 }
@@ -5014,6 +5064,10 @@ func (o CloudProviderSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyInterv
 
 func (o CloudProviderSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyType() pulumi.StringOutput {
 	return o.ApplyT(func(v CloudProviderSnapshotBackupPolicyPolicyPolicyItem) string { return v.FrequencyType }).(pulumi.StringOutput)
+}
+
+func (o CloudProviderSnapshotBackupPolicyPolicyPolicyItemOutput) Id() pulumi.StringOutput {
+	return o.ApplyT(func(v CloudProviderSnapshotBackupPolicyPolicyPolicyItem) string { return v.Id }).(pulumi.StringOutput)
 }
 
 func (o CloudProviderSnapshotBackupPolicyPolicyPolicyItemOutput) RetentionUnit() pulumi.StringOutput {
@@ -6627,6 +6681,8 @@ func (o ClusterSnapshotBackupPolicyArrayOutput) Index(i pulumi.IntInput) Cluster
 }
 
 type ClusterSnapshotBackupPolicyPolicy struct {
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id          *string                                       `pulumi:"id"`
 	PolicyItems []ClusterSnapshotBackupPolicyPolicyPolicyItem `pulumi:"policyItems"`
 }
 
@@ -6642,6 +6698,8 @@ type ClusterSnapshotBackupPolicyPolicyInput interface {
 }
 
 type ClusterSnapshotBackupPolicyPolicyArgs struct {
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id          pulumi.StringPtrInput                                 `pulumi:"id"`
 	PolicyItems ClusterSnapshotBackupPolicyPolicyPolicyItemArrayInput `pulumi:"policyItems"`
 }
 
@@ -6696,6 +6754,11 @@ func (o ClusterSnapshotBackupPolicyPolicyOutput) ToClusterSnapshotBackupPolicyPo
 	return o
 }
 
+// Unique identifer of the replication document for a zone in a Global Cluster.
+func (o ClusterSnapshotBackupPolicyPolicyOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ClusterSnapshotBackupPolicyPolicy) *string { return v.Id }).(pulumi.StringPtrOutput)
+}
+
 func (o ClusterSnapshotBackupPolicyPolicyOutput) PolicyItems() ClusterSnapshotBackupPolicyPolicyPolicyItemArrayOutput {
 	return o.ApplyT(func(v ClusterSnapshotBackupPolicyPolicy) []ClusterSnapshotBackupPolicyPolicyPolicyItem {
 		return v.PolicyItems
@@ -6725,8 +6788,10 @@ func (o ClusterSnapshotBackupPolicyPolicyArrayOutput) Index(i pulumi.IntInput) C
 type ClusterSnapshotBackupPolicyPolicyPolicyItem struct {
 	FrequencyInterval *int    `pulumi:"frequencyInterval"`
 	FrequencyType     *string `pulumi:"frequencyType"`
-	RetentionUnit     *string `pulumi:"retentionUnit"`
-	RetentionValue    *int    `pulumi:"retentionValue"`
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id             *string `pulumi:"id"`
+	RetentionUnit  *string `pulumi:"retentionUnit"`
+	RetentionValue *int    `pulumi:"retentionValue"`
 }
 
 // ClusterSnapshotBackupPolicyPolicyPolicyItemInput is an input type that accepts ClusterSnapshotBackupPolicyPolicyPolicyItemArgs and ClusterSnapshotBackupPolicyPolicyPolicyItemOutput values.
@@ -6743,8 +6808,10 @@ type ClusterSnapshotBackupPolicyPolicyPolicyItemInput interface {
 type ClusterSnapshotBackupPolicyPolicyPolicyItemArgs struct {
 	FrequencyInterval pulumi.IntPtrInput    `pulumi:"frequencyInterval"`
 	FrequencyType     pulumi.StringPtrInput `pulumi:"frequencyType"`
-	RetentionUnit     pulumi.StringPtrInput `pulumi:"retentionUnit"`
-	RetentionValue    pulumi.IntPtrInput    `pulumi:"retentionValue"`
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id             pulumi.StringPtrInput `pulumi:"id"`
+	RetentionUnit  pulumi.StringPtrInput `pulumi:"retentionUnit"`
+	RetentionValue pulumi.IntPtrInput    `pulumi:"retentionValue"`
 }
 
 func (ClusterSnapshotBackupPolicyPolicyPolicyItemArgs) ElementType() reflect.Type {
@@ -6804,6 +6871,11 @@ func (o ClusterSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyInterval() p
 
 func (o ClusterSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ClusterSnapshotBackupPolicyPolicyPolicyItem) *string { return v.FrequencyType }).(pulumi.StringPtrOutput)
+}
+
+// Unique identifer of the replication document for a zone in a Global Cluster.
+func (o ClusterSnapshotBackupPolicyPolicyPolicyItemOutput) Id() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ClusterSnapshotBackupPolicyPolicyPolicyItem) *string { return v.Id }).(pulumi.StringPtrOutput)
 }
 
 func (o ClusterSnapshotBackupPolicyPolicyPolicyItemOutput) RetentionUnit() pulumi.StringPtrOutput {
@@ -10941,6 +11013,7 @@ func (o ServerlessInstanceLinkArrayOutput) Index(i pulumi.IntInput) ServerlessIn
 type X509AuthenticationDatabaseUserCertificate struct {
 	CreatedAt *string `pulumi:"createdAt"`
 	GroupId   *string `pulumi:"groupId"`
+	Id        *int    `pulumi:"id"`
 	NotAfter  *string `pulumi:"notAfter"`
 	Subject   *string `pulumi:"subject"`
 }
@@ -10959,6 +11032,7 @@ type X509AuthenticationDatabaseUserCertificateInput interface {
 type X509AuthenticationDatabaseUserCertificateArgs struct {
 	CreatedAt pulumi.StringPtrInput `pulumi:"createdAt"`
 	GroupId   pulumi.StringPtrInput `pulumi:"groupId"`
+	Id        pulumi.IntPtrInput    `pulumi:"id"`
 	NotAfter  pulumi.StringPtrInput `pulumi:"notAfter"`
 	Subject   pulumi.StringPtrInput `pulumi:"subject"`
 }
@@ -11020,6 +11094,10 @@ func (o X509AuthenticationDatabaseUserCertificateOutput) CreatedAt() pulumi.Stri
 
 func (o X509AuthenticationDatabaseUserCertificateOutput) GroupId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v X509AuthenticationDatabaseUserCertificate) *string { return v.GroupId }).(pulumi.StringPtrOutput)
+}
+
+func (o X509AuthenticationDatabaseUserCertificateOutput) Id() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v X509AuthenticationDatabaseUserCertificate) *int { return v.Id }).(pulumi.IntPtrOutput)
 }
 
 func (o X509AuthenticationDatabaseUserCertificateOutput) NotAfter() pulumi.StringPtrOutput {
@@ -19993,6 +20071,8 @@ func (o GetClusterSnapshotBackupPolicyArrayOutput) Index(i pulumi.IntInput) GetC
 }
 
 type GetClusterSnapshotBackupPolicyPolicy struct {
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id          string                                           `pulumi:"id"`
 	PolicyItems []GetClusterSnapshotBackupPolicyPolicyPolicyItem `pulumi:"policyItems"`
 }
 
@@ -20008,6 +20088,8 @@ type GetClusterSnapshotBackupPolicyPolicyInput interface {
 }
 
 type GetClusterSnapshotBackupPolicyPolicyArgs struct {
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id          pulumi.StringInput                                       `pulumi:"id"`
 	PolicyItems GetClusterSnapshotBackupPolicyPolicyPolicyItemArrayInput `pulumi:"policyItems"`
 }
 
@@ -20062,6 +20144,11 @@ func (o GetClusterSnapshotBackupPolicyPolicyOutput) ToGetClusterSnapshotBackupPo
 	return o
 }
 
+// Unique identifer of the replication document for a zone in a Global Cluster.
+func (o GetClusterSnapshotBackupPolicyPolicyOutput) Id() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClusterSnapshotBackupPolicyPolicy) string { return v.Id }).(pulumi.StringOutput)
+}
+
 func (o GetClusterSnapshotBackupPolicyPolicyOutput) PolicyItems() GetClusterSnapshotBackupPolicyPolicyPolicyItemArrayOutput {
 	return o.ApplyT(func(v GetClusterSnapshotBackupPolicyPolicy) []GetClusterSnapshotBackupPolicyPolicyPolicyItem {
 		return v.PolicyItems
@@ -20091,8 +20178,10 @@ func (o GetClusterSnapshotBackupPolicyPolicyArrayOutput) Index(i pulumi.IntInput
 type GetClusterSnapshotBackupPolicyPolicyPolicyItem struct {
 	FrequencyInterval int    `pulumi:"frequencyInterval"`
 	FrequencyType     string `pulumi:"frequencyType"`
-	RetentionUnit     string `pulumi:"retentionUnit"`
-	RetentionValue    int    `pulumi:"retentionValue"`
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id             string `pulumi:"id"`
+	RetentionUnit  string `pulumi:"retentionUnit"`
+	RetentionValue int    `pulumi:"retentionValue"`
 }
 
 // GetClusterSnapshotBackupPolicyPolicyPolicyItemInput is an input type that accepts GetClusterSnapshotBackupPolicyPolicyPolicyItemArgs and GetClusterSnapshotBackupPolicyPolicyPolicyItemOutput values.
@@ -20109,8 +20198,10 @@ type GetClusterSnapshotBackupPolicyPolicyPolicyItemInput interface {
 type GetClusterSnapshotBackupPolicyPolicyPolicyItemArgs struct {
 	FrequencyInterval pulumi.IntInput    `pulumi:"frequencyInterval"`
 	FrequencyType     pulumi.StringInput `pulumi:"frequencyType"`
-	RetentionUnit     pulumi.StringInput `pulumi:"retentionUnit"`
-	RetentionValue    pulumi.IntInput    `pulumi:"retentionValue"`
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id             pulumi.StringInput `pulumi:"id"`
+	RetentionUnit  pulumi.StringInput `pulumi:"retentionUnit"`
+	RetentionValue pulumi.IntInput    `pulumi:"retentionValue"`
 }
 
 func (GetClusterSnapshotBackupPolicyPolicyPolicyItemArgs) ElementType() reflect.Type {
@@ -20170,6 +20261,11 @@ func (o GetClusterSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyInterval(
 
 func (o GetClusterSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyType() pulumi.StringOutput {
 	return o.ApplyT(func(v GetClusterSnapshotBackupPolicyPolicyPolicyItem) string { return v.FrequencyType }).(pulumi.StringOutput)
+}
+
+// Unique identifer of the replication document for a zone in a Global Cluster.
+func (o GetClusterSnapshotBackupPolicyPolicyPolicyItemOutput) Id() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClusterSnapshotBackupPolicyPolicyPolicyItem) string { return v.Id }).(pulumi.StringOutput)
 }
 
 func (o GetClusterSnapshotBackupPolicyPolicyPolicyItemOutput) RetentionUnit() pulumi.StringOutput {
@@ -21833,6 +21929,8 @@ func (o GetClustersResultSnapshotBackupPolicyArrayOutput) Index(i pulumi.IntInpu
 }
 
 type GetClustersResultSnapshotBackupPolicyPolicy struct {
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id          string                                                  `pulumi:"id"`
 	PolicyItems []GetClustersResultSnapshotBackupPolicyPolicyPolicyItem `pulumi:"policyItems"`
 }
 
@@ -21848,6 +21946,8 @@ type GetClustersResultSnapshotBackupPolicyPolicyInput interface {
 }
 
 type GetClustersResultSnapshotBackupPolicyPolicyArgs struct {
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id          pulumi.StringInput                                              `pulumi:"id"`
 	PolicyItems GetClustersResultSnapshotBackupPolicyPolicyPolicyItemArrayInput `pulumi:"policyItems"`
 }
 
@@ -21902,6 +22002,11 @@ func (o GetClustersResultSnapshotBackupPolicyPolicyOutput) ToGetClustersResultSn
 	return o
 }
 
+// Unique identifer of the replication document for a zone in a Global Cluster.
+func (o GetClustersResultSnapshotBackupPolicyPolicyOutput) Id() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClustersResultSnapshotBackupPolicyPolicy) string { return v.Id }).(pulumi.StringOutput)
+}
+
 func (o GetClustersResultSnapshotBackupPolicyPolicyOutput) PolicyItems() GetClustersResultSnapshotBackupPolicyPolicyPolicyItemArrayOutput {
 	return o.ApplyT(func(v GetClustersResultSnapshotBackupPolicyPolicy) []GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
 		return v.PolicyItems
@@ -21931,8 +22036,10 @@ func (o GetClustersResultSnapshotBackupPolicyPolicyArrayOutput) Index(i pulumi.I
 type GetClustersResultSnapshotBackupPolicyPolicyPolicyItem struct {
 	FrequencyInterval int    `pulumi:"frequencyInterval"`
 	FrequencyType     string `pulumi:"frequencyType"`
-	RetentionUnit     string `pulumi:"retentionUnit"`
-	RetentionValue    int    `pulumi:"retentionValue"`
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id             string `pulumi:"id"`
+	RetentionUnit  string `pulumi:"retentionUnit"`
+	RetentionValue int    `pulumi:"retentionValue"`
 }
 
 // GetClustersResultSnapshotBackupPolicyPolicyPolicyItemInput is an input type that accepts GetClustersResultSnapshotBackupPolicyPolicyPolicyItemArgs and GetClustersResultSnapshotBackupPolicyPolicyPolicyItemOutput values.
@@ -21949,8 +22056,10 @@ type GetClustersResultSnapshotBackupPolicyPolicyPolicyItemInput interface {
 type GetClustersResultSnapshotBackupPolicyPolicyPolicyItemArgs struct {
 	FrequencyInterval pulumi.IntInput    `pulumi:"frequencyInterval"`
 	FrequencyType     pulumi.StringInput `pulumi:"frequencyType"`
-	RetentionUnit     pulumi.StringInput `pulumi:"retentionUnit"`
-	RetentionValue    pulumi.IntInput    `pulumi:"retentionValue"`
+	// Unique identifer of the replication document for a zone in a Global Cluster.
+	Id             pulumi.StringInput `pulumi:"id"`
+	RetentionUnit  pulumi.StringInput `pulumi:"retentionUnit"`
+	RetentionValue pulumi.IntInput    `pulumi:"retentionValue"`
 }
 
 func (GetClustersResultSnapshotBackupPolicyPolicyPolicyItemArgs) ElementType() reflect.Type {
@@ -22010,6 +22119,11 @@ func (o GetClustersResultSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyIn
 
 func (o GetClustersResultSnapshotBackupPolicyPolicyPolicyItemOutput) FrequencyType() pulumi.StringOutput {
 	return o.ApplyT(func(v GetClustersResultSnapshotBackupPolicyPolicyPolicyItem) string { return v.FrequencyType }).(pulumi.StringOutput)
+}
+
+// Unique identifer of the replication document for a zone in a Global Cluster.
+func (o GetClustersResultSnapshotBackupPolicyPolicyPolicyItemOutput) Id() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClustersResultSnapshotBackupPolicyPolicyPolicyItem) string { return v.Id }).(pulumi.StringOutput)
 }
 
 func (o GetClustersResultSnapshotBackupPolicyPolicyPolicyItemOutput) RetentionUnit() pulumi.StringOutput {

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/AdvancedClusterReplicationSpecArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/AdvancedClusterReplicationSpecArgs.java
@@ -34,6 +34,13 @@ public final class AdvancedClusterReplicationSpecArgs extends com.pulumi.resourc
         return Optional.ofNullable(this.containerId);
     }
 
+    @Import(name="id")
+    private @Nullable Output<String> id;
+
+    public Optional<Output<String>> id() {
+        return Optional.ofNullable(this.id);
+    }
+
     /**
      * Provide this value if you set a `cluster_type` of SHARDED or GEOSHARDED. Omit this value if you selected a `cluster_type` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `num_shards` value of 1 and a `cluster_type` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don&#39;t create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don&#39;t provide the same benefits as multi-shard configurations.
      * 
@@ -83,6 +90,7 @@ public final class AdvancedClusterReplicationSpecArgs extends com.pulumi.resourc
 
     private AdvancedClusterReplicationSpecArgs(AdvancedClusterReplicationSpecArgs $) {
         this.containerId = $.containerId;
+        this.id = $.id;
         this.numShards = $.numShards;
         this.regionConfigs = $.regionConfigs;
         this.zoneName = $.zoneName;
@@ -125,6 +133,15 @@ public final class AdvancedClusterReplicationSpecArgs extends com.pulumi.resourc
          */
         public Builder containerId(Map<String,String> containerId) {
             return containerId(Output.of(containerId));
+        }
+
+        public Builder id(@Nullable Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        public Builder id(String id) {
+            return id(Output.of(id));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSchedulePolicyItemDailyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSchedulePolicyItemDailyArgs.java
@@ -46,6 +46,13 @@ public final class CloudBackupSchedulePolicyItemDailyArgs extends com.pulumi.res
         return Optional.ofNullable(this.frequencyType);
     }
 
+    @Import(name="id")
+    private @Nullable Output<String> id;
+
+    public Optional<Output<String>> id() {
+        return Optional.ofNullable(this.id);
+    }
+
     /**
      * Scope of the backup policy item: days, weeks, or months.
      * 
@@ -81,6 +88,7 @@ public final class CloudBackupSchedulePolicyItemDailyArgs extends com.pulumi.res
     private CloudBackupSchedulePolicyItemDailyArgs(CloudBackupSchedulePolicyItemDailyArgs $) {
         this.frequencyInterval = $.frequencyInterval;
         this.frequencyType = $.frequencyType;
+        this.id = $.id;
         this.retentionUnit = $.retentionUnit;
         this.retentionValue = $.retentionValue;
     }
@@ -143,6 +151,15 @@ public final class CloudBackupSchedulePolicyItemDailyArgs extends com.pulumi.res
          */
         public Builder frequencyType(String frequencyType) {
             return frequencyType(Output.of(frequencyType));
+        }
+
+        public Builder id(@Nullable Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        public Builder id(String id) {
+            return id(Output.of(id));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSchedulePolicyItemMonthlyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSchedulePolicyItemMonthlyArgs.java
@@ -46,6 +46,13 @@ public final class CloudBackupSchedulePolicyItemMonthlyArgs extends com.pulumi.r
         return Optional.ofNullable(this.frequencyType);
     }
 
+    @Import(name="id")
+    private @Nullable Output<String> id;
+
+    public Optional<Output<String>> id() {
+        return Optional.ofNullable(this.id);
+    }
+
     /**
      * Scope of the backup policy item: days, weeks, or months.
      * 
@@ -81,6 +88,7 @@ public final class CloudBackupSchedulePolicyItemMonthlyArgs extends com.pulumi.r
     private CloudBackupSchedulePolicyItemMonthlyArgs(CloudBackupSchedulePolicyItemMonthlyArgs $) {
         this.frequencyInterval = $.frequencyInterval;
         this.frequencyType = $.frequencyType;
+        this.id = $.id;
         this.retentionUnit = $.retentionUnit;
         this.retentionValue = $.retentionValue;
     }
@@ -143,6 +151,15 @@ public final class CloudBackupSchedulePolicyItemMonthlyArgs extends com.pulumi.r
          */
         public Builder frequencyType(String frequencyType) {
             return frequencyType(Output.of(frequencyType));
+        }
+
+        public Builder id(@Nullable Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        public Builder id(String id) {
+            return id(Output.of(id));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSchedulePolicyItemWeeklyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSchedulePolicyItemWeeklyArgs.java
@@ -46,6 +46,13 @@ public final class CloudBackupSchedulePolicyItemWeeklyArgs extends com.pulumi.re
         return Optional.ofNullable(this.frequencyType);
     }
 
+    @Import(name="id")
+    private @Nullable Output<String> id;
+
+    public Optional<Output<String>> id() {
+        return Optional.ofNullable(this.id);
+    }
+
     /**
      * Scope of the backup policy item: days, weeks, or months.
      * 
@@ -81,6 +88,7 @@ public final class CloudBackupSchedulePolicyItemWeeklyArgs extends com.pulumi.re
     private CloudBackupSchedulePolicyItemWeeklyArgs(CloudBackupSchedulePolicyItemWeeklyArgs $) {
         this.frequencyInterval = $.frequencyInterval;
         this.frequencyType = $.frequencyType;
+        this.id = $.id;
         this.retentionUnit = $.retentionUnit;
         this.retentionValue = $.retentionValue;
     }
@@ -143,6 +151,15 @@ public final class CloudBackupSchedulePolicyItemWeeklyArgs extends com.pulumi.re
          */
         public Builder frequencyType(String frequencyType) {
             return frequencyType(Output.of(frequencyType));
+        }
+
+        public Builder id(@Nullable Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        public Builder id(String id) {
+            return id(Output.of(id));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSnapshotMemberArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudBackupSnapshotMemberArgs.java
@@ -31,6 +31,21 @@ public final class CloudBackupSnapshotMemberArgs extends com.pulumi.resources.Re
     }
 
     /**
+     * Unique identifier for the sharded cluster snapshot.
+     * 
+     */
+    @Import(name="id")
+    private @Nullable Output<String> id;
+
+    /**
+     * @return Unique identifier for the sharded cluster snapshot.
+     * 
+     */
+    public Optional<Output<String>> id() {
+        return Optional.ofNullable(this.id);
+    }
+
+    /**
      * Label given to a shard or config server from which Atlas took this snapshot.
      * 
      */
@@ -49,6 +64,7 @@ public final class CloudBackupSnapshotMemberArgs extends com.pulumi.resources.Re
 
     private CloudBackupSnapshotMemberArgs(CloudBackupSnapshotMemberArgs $) {
         this.cloudProvider = $.cloudProvider;
+        this.id = $.id;
         this.replicaSetName = $.replicaSetName;
     }
 
@@ -89,6 +105,27 @@ public final class CloudBackupSnapshotMemberArgs extends com.pulumi.resources.Re
          */
         public Builder cloudProvider(String cloudProvider) {
             return cloudProvider(Output.of(cloudProvider));
+        }
+
+        /**
+         * @param id Unique identifier for the sharded cluster snapshot.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder id(@Nullable Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        /**
+         * @param id Unique identifier for the sharded cluster snapshot.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder id(String id) {
+            return id(Output.of(id));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudProviderSnapshotBackupPolicyPolicyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudProviderSnapshotBackupPolicyPolicyArgs.java
@@ -6,6 +6,7 @@ package com.pulumi.mongodbatlas.inputs;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.mongodbatlas.inputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs;
+import java.lang.String;
 import java.util.List;
 import java.util.Objects;
 
@@ -13,6 +14,13 @@ import java.util.Objects;
 public final class CloudProviderSnapshotBackupPolicyPolicyArgs extends com.pulumi.resources.ResourceArgs {
 
     public static final CloudProviderSnapshotBackupPolicyPolicyArgs Empty = new CloudProviderSnapshotBackupPolicyPolicyArgs();
+
+    @Import(name="id", required=true)
+    private Output<String> id;
+
+    public Output<String> id() {
+        return this.id;
+    }
 
     @Import(name="policyItems", required=true)
     private Output<List<CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs>> policyItems;
@@ -24,6 +32,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicyArgs extends com.pulum
     private CloudProviderSnapshotBackupPolicyPolicyArgs() {}
 
     private CloudProviderSnapshotBackupPolicyPolicyArgs(CloudProviderSnapshotBackupPolicyPolicyArgs $) {
+        this.id = $.id;
         this.policyItems = $.policyItems;
     }
 
@@ -45,6 +54,15 @@ public final class CloudProviderSnapshotBackupPolicyPolicyArgs extends com.pulum
             $ = new CloudProviderSnapshotBackupPolicyPolicyArgs(Objects.requireNonNull(defaults));
         }
 
+        public Builder id(Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        public Builder id(String id) {
+            return id(Output.of(id));
+        }
+
         public Builder policyItems(Output<List<CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs>> policyItems) {
             $.policyItems = policyItems;
             return this;
@@ -59,6 +77,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicyArgs extends com.pulum
         }
 
         public CloudProviderSnapshotBackupPolicyPolicyArgs build() {
+            $.id = Objects.requireNonNull($.id, "expected parameter 'id' to be non-null");
             $.policyItems = Objects.requireNonNull($.policyItems, "expected parameter 'policyItems' to be non-null");
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs.java
@@ -28,6 +28,13 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs extends
         return this.frequencyType;
     }
 
+    @Import(name="id", required=true)
+    private Output<String> id;
+
+    public Output<String> id() {
+        return this.id;
+    }
+
     @Import(name="retentionUnit", required=true)
     private Output<String> retentionUnit;
 
@@ -47,6 +54,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs extends
     private CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs(CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs $) {
         this.frequencyInterval = $.frequencyInterval;
         this.frequencyType = $.frequencyType;
+        this.id = $.id;
         this.retentionUnit = $.retentionUnit;
         this.retentionValue = $.retentionValue;
     }
@@ -87,6 +95,15 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs extends
             return frequencyType(Output.of(frequencyType));
         }
 
+        public Builder id(Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        public Builder id(String id) {
+            return id(Output.of(id));
+        }
+
         public Builder retentionUnit(Output<String> retentionUnit) {
             $.retentionUnit = retentionUnit;
             return this;
@@ -108,6 +125,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs extends
         public CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs build() {
             $.frequencyInterval = Objects.requireNonNull($.frequencyInterval, "expected parameter 'frequencyInterval' to be non-null");
             $.frequencyType = Objects.requireNonNull($.frequencyType, "expected parameter 'frequencyType' to be non-null");
+            $.id = Objects.requireNonNull($.id, "expected parameter 'id' to be non-null");
             $.retentionUnit = Objects.requireNonNull($.retentionUnit, "expected parameter 'retentionUnit' to be non-null");
             $.retentionValue = Objects.requireNonNull($.retentionValue, "expected parameter 'retentionValue' to be non-null");
             return $;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/ClusterSnapshotBackupPolicyPolicyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/ClusterSnapshotBackupPolicyPolicyArgs.java
@@ -6,6 +6,7 @@ package com.pulumi.mongodbatlas.inputs;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.mongodbatlas.inputs.ClusterSnapshotBackupPolicyPolicyPolicyItemArgs;
+import java.lang.String;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -15,6 +16,21 @@ import javax.annotation.Nullable;
 public final class ClusterSnapshotBackupPolicyPolicyArgs extends com.pulumi.resources.ResourceArgs {
 
     public static final ClusterSnapshotBackupPolicyPolicyArgs Empty = new ClusterSnapshotBackupPolicyPolicyArgs();
+
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    @Import(name="id")
+    private @Nullable Output<String> id;
+
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public Optional<Output<String>> id() {
+        return Optional.ofNullable(this.id);
+    }
 
     @Import(name="policyItems")
     private @Nullable Output<List<ClusterSnapshotBackupPolicyPolicyPolicyItemArgs>> policyItems;
@@ -26,6 +42,7 @@ public final class ClusterSnapshotBackupPolicyPolicyArgs extends com.pulumi.reso
     private ClusterSnapshotBackupPolicyPolicyArgs() {}
 
     private ClusterSnapshotBackupPolicyPolicyArgs(ClusterSnapshotBackupPolicyPolicyArgs $) {
+        this.id = $.id;
         this.policyItems = $.policyItems;
     }
 
@@ -45,6 +62,27 @@ public final class ClusterSnapshotBackupPolicyPolicyArgs extends com.pulumi.reso
 
         public Builder(ClusterSnapshotBackupPolicyPolicyArgs defaults) {
             $ = new ClusterSnapshotBackupPolicyPolicyArgs(Objects.requireNonNull(defaults));
+        }
+
+        /**
+         * @param id Unique identifer of the replication document for a zone in a Global Cluster.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder id(@Nullable Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        /**
+         * @param id Unique identifer of the replication document for a zone in a Global Cluster.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder id(String id) {
+            return id(Output.of(id));
         }
 
         public Builder policyItems(@Nullable Output<List<ClusterSnapshotBackupPolicyPolicyPolicyItemArgs>> policyItems) {

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/ClusterSnapshotBackupPolicyPolicyPolicyItemArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/ClusterSnapshotBackupPolicyPolicyPolicyItemArgs.java
@@ -30,6 +30,21 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItemArgs extends com.p
         return Optional.ofNullable(this.frequencyType);
     }
 
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    @Import(name="id")
+    private @Nullable Output<String> id;
+
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public Optional<Output<String>> id() {
+        return Optional.ofNullable(this.id);
+    }
+
     @Import(name="retentionUnit")
     private @Nullable Output<String> retentionUnit;
 
@@ -49,6 +64,7 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItemArgs extends com.p
     private ClusterSnapshotBackupPolicyPolicyPolicyItemArgs(ClusterSnapshotBackupPolicyPolicyPolicyItemArgs $) {
         this.frequencyInterval = $.frequencyInterval;
         this.frequencyType = $.frequencyType;
+        this.id = $.id;
         this.retentionUnit = $.retentionUnit;
         this.retentionValue = $.retentionValue;
     }
@@ -87,6 +103,27 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItemArgs extends com.p
 
         public Builder frequencyType(String frequencyType) {
             return frequencyType(Output.of(frequencyType));
+        }
+
+        /**
+         * @param id Unique identifer of the replication document for a zone in a Global Cluster.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder id(@Nullable Output<String> id) {
+            $.id = id;
+            return this;
+        }
+
+        /**
+         * @param id Unique identifer of the replication document for a zone in a Global Cluster.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder id(String id) {
+            return id(Output.of(id));
         }
 
         public Builder retentionUnit(@Nullable Output<String> retentionUnit) {

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/X509AuthenticationDatabaseUserCertificateArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/inputs/X509AuthenticationDatabaseUserCertificateArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.mongodbatlas.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -29,6 +30,13 @@ public final class X509AuthenticationDatabaseUserCertificateArgs extends com.pul
         return Optional.ofNullable(this.groupId);
     }
 
+    @Import(name="id")
+    private @Nullable Output<Integer> id;
+
+    public Optional<Output<Integer>> id() {
+        return Optional.ofNullable(this.id);
+    }
+
     @Import(name="notAfter")
     private @Nullable Output<String> notAfter;
 
@@ -48,6 +56,7 @@ public final class X509AuthenticationDatabaseUserCertificateArgs extends com.pul
     private X509AuthenticationDatabaseUserCertificateArgs(X509AuthenticationDatabaseUserCertificateArgs $) {
         this.createdAt = $.createdAt;
         this.groupId = $.groupId;
+        this.id = $.id;
         this.notAfter = $.notAfter;
         this.subject = $.subject;
     }
@@ -86,6 +95,15 @@ public final class X509AuthenticationDatabaseUserCertificateArgs extends com.pul
 
         public Builder groupId(String groupId) {
             return groupId(Output.of(groupId));
+        }
+
+        public Builder id(@Nullable Output<Integer> id) {
+            $.id = id;
+            return this;
+        }
+
+        public Builder id(Integer id) {
+            return id(Output.of(id));
         }
 
         public Builder notAfter(@Nullable Output<String> notAfter) {

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/AdvancedClusterReplicationSpec.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/AdvancedClusterReplicationSpec.java
@@ -20,6 +20,7 @@ public final class AdvancedClusterReplicationSpec {
      * 
      */
     private @Nullable Map<String,String> containerId;
+    private @Nullable String id;
     /**
      * @return Provide this value if you set a `cluster_type` of SHARDED or GEOSHARDED. Omit this value if you selected a `cluster_type` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `num_shards` value of 1 and a `cluster_type` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don&#39;t create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don&#39;t provide the same benefits as multi-shard configurations.
      * 
@@ -43,6 +44,9 @@ public final class AdvancedClusterReplicationSpec {
      */
     public Map<String,String> containerId() {
         return this.containerId == null ? Map.of() : this.containerId;
+    }
+    public Optional<String> id() {
+        return Optional.ofNullable(this.id);
     }
     /**
      * @return Provide this value if you set a `cluster_type` of SHARDED or GEOSHARDED. Omit this value if you selected a `cluster_type` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `num_shards` value of 1 and a `cluster_type` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don&#39;t create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don&#39;t provide the same benefits as multi-shard configurations.
@@ -76,6 +80,7 @@ public final class AdvancedClusterReplicationSpec {
     @CustomType.Builder
     public static final class Builder {
         private @Nullable Map<String,String> containerId;
+        private @Nullable String id;
         private @Nullable Integer numShards;
         private List<AdvancedClusterReplicationSpecRegionConfig> regionConfigs;
         private @Nullable String zoneName;
@@ -83,6 +88,7 @@ public final class AdvancedClusterReplicationSpec {
         public Builder(AdvancedClusterReplicationSpec defaults) {
     	      Objects.requireNonNull(defaults);
     	      this.containerId = defaults.containerId;
+    	      this.id = defaults.id;
     	      this.numShards = defaults.numShards;
     	      this.regionConfigs = defaults.regionConfigs;
     	      this.zoneName = defaults.zoneName;
@@ -91,6 +97,11 @@ public final class AdvancedClusterReplicationSpec {
         @CustomType.Setter
         public Builder containerId(@Nullable Map<String,String> containerId) {
             this.containerId = containerId;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(@Nullable String id) {
+            this.id = id;
             return this;
         }
         @CustomType.Setter
@@ -114,6 +125,7 @@ public final class AdvancedClusterReplicationSpec {
         public AdvancedClusterReplicationSpec build() {
             final var o = new AdvancedClusterReplicationSpec();
             o.containerId = containerId;
+            o.id = id;
             o.numShards = numShards;
             o.regionConfigs = regionConfigs;
             o.zoneName = zoneName;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSchedulePolicyItemDaily.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSchedulePolicyItemDaily.java
@@ -22,6 +22,7 @@ public final class CloudBackupSchedulePolicyItemDaily {
      * 
      */
     private @Nullable String frequencyType;
+    private @Nullable String id;
     /**
      * @return Scope of the backup policy item: days, weeks, or months.
      * 
@@ -47,6 +48,9 @@ public final class CloudBackupSchedulePolicyItemDaily {
      */
     public Optional<String> frequencyType() {
         return Optional.ofNullable(this.frequencyType);
+    }
+    public Optional<String> id() {
+        return Optional.ofNullable(this.id);
     }
     /**
      * @return Scope of the backup policy item: days, weeks, or months.
@@ -74,6 +78,7 @@ public final class CloudBackupSchedulePolicyItemDaily {
     public static final class Builder {
         private Integer frequencyInterval;
         private @Nullable String frequencyType;
+        private @Nullable String id;
         private String retentionUnit;
         private Integer retentionValue;
         public Builder() {}
@@ -81,6 +86,7 @@ public final class CloudBackupSchedulePolicyItemDaily {
     	      Objects.requireNonNull(defaults);
     	      this.frequencyInterval = defaults.frequencyInterval;
     	      this.frequencyType = defaults.frequencyType;
+    	      this.id = defaults.id;
     	      this.retentionUnit = defaults.retentionUnit;
     	      this.retentionValue = defaults.retentionValue;
         }
@@ -93,6 +99,11 @@ public final class CloudBackupSchedulePolicyItemDaily {
         @CustomType.Setter
         public Builder frequencyType(@Nullable String frequencyType) {
             this.frequencyType = frequencyType;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(@Nullable String id) {
+            this.id = id;
             return this;
         }
         @CustomType.Setter
@@ -109,6 +120,7 @@ public final class CloudBackupSchedulePolicyItemDaily {
             final var o = new CloudBackupSchedulePolicyItemDaily();
             o.frequencyInterval = frequencyInterval;
             o.frequencyType = frequencyType;
+            o.id = id;
             o.retentionUnit = retentionUnit;
             o.retentionValue = retentionValue;
             return o;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSchedulePolicyItemMonthly.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSchedulePolicyItemMonthly.java
@@ -22,6 +22,7 @@ public final class CloudBackupSchedulePolicyItemMonthly {
      * 
      */
     private @Nullable String frequencyType;
+    private @Nullable String id;
     /**
      * @return Scope of the backup policy item: days, weeks, or months.
      * 
@@ -47,6 +48,9 @@ public final class CloudBackupSchedulePolicyItemMonthly {
      */
     public Optional<String> frequencyType() {
         return Optional.ofNullable(this.frequencyType);
+    }
+    public Optional<String> id() {
+        return Optional.ofNullable(this.id);
     }
     /**
      * @return Scope of the backup policy item: days, weeks, or months.
@@ -74,6 +78,7 @@ public final class CloudBackupSchedulePolicyItemMonthly {
     public static final class Builder {
         private Integer frequencyInterval;
         private @Nullable String frequencyType;
+        private @Nullable String id;
         private String retentionUnit;
         private Integer retentionValue;
         public Builder() {}
@@ -81,6 +86,7 @@ public final class CloudBackupSchedulePolicyItemMonthly {
     	      Objects.requireNonNull(defaults);
     	      this.frequencyInterval = defaults.frequencyInterval;
     	      this.frequencyType = defaults.frequencyType;
+    	      this.id = defaults.id;
     	      this.retentionUnit = defaults.retentionUnit;
     	      this.retentionValue = defaults.retentionValue;
         }
@@ -93,6 +99,11 @@ public final class CloudBackupSchedulePolicyItemMonthly {
         @CustomType.Setter
         public Builder frequencyType(@Nullable String frequencyType) {
             this.frequencyType = frequencyType;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(@Nullable String id) {
+            this.id = id;
             return this;
         }
         @CustomType.Setter
@@ -109,6 +120,7 @@ public final class CloudBackupSchedulePolicyItemMonthly {
             final var o = new CloudBackupSchedulePolicyItemMonthly();
             o.frequencyInterval = frequencyInterval;
             o.frequencyType = frequencyType;
+            o.id = id;
             o.retentionUnit = retentionUnit;
             o.retentionValue = retentionValue;
             return o;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSchedulePolicyItemWeekly.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSchedulePolicyItemWeekly.java
@@ -22,6 +22,7 @@ public final class CloudBackupSchedulePolicyItemWeekly {
      * 
      */
     private @Nullable String frequencyType;
+    private @Nullable String id;
     /**
      * @return Scope of the backup policy item: days, weeks, or months.
      * 
@@ -47,6 +48,9 @@ public final class CloudBackupSchedulePolicyItemWeekly {
      */
     public Optional<String> frequencyType() {
         return Optional.ofNullable(this.frequencyType);
+    }
+    public Optional<String> id() {
+        return Optional.ofNullable(this.id);
     }
     /**
      * @return Scope of the backup policy item: days, weeks, or months.
@@ -74,6 +78,7 @@ public final class CloudBackupSchedulePolicyItemWeekly {
     public static final class Builder {
         private Integer frequencyInterval;
         private @Nullable String frequencyType;
+        private @Nullable String id;
         private String retentionUnit;
         private Integer retentionValue;
         public Builder() {}
@@ -81,6 +86,7 @@ public final class CloudBackupSchedulePolicyItemWeekly {
     	      Objects.requireNonNull(defaults);
     	      this.frequencyInterval = defaults.frequencyInterval;
     	      this.frequencyType = defaults.frequencyType;
+    	      this.id = defaults.id;
     	      this.retentionUnit = defaults.retentionUnit;
     	      this.retentionValue = defaults.retentionValue;
         }
@@ -93,6 +99,11 @@ public final class CloudBackupSchedulePolicyItemWeekly {
         @CustomType.Setter
         public Builder frequencyType(@Nullable String frequencyType) {
             this.frequencyType = frequencyType;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(@Nullable String id) {
+            this.id = id;
             return this;
         }
         @CustomType.Setter
@@ -109,6 +120,7 @@ public final class CloudBackupSchedulePolicyItemWeekly {
             final var o = new CloudBackupSchedulePolicyItemWeekly();
             o.frequencyInterval = frequencyInterval;
             o.frequencyType = frequencyType;
+            o.id = id;
             o.retentionUnit = retentionUnit;
             o.retentionValue = retentionValue;
             return o;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSnapshotMember.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudBackupSnapshotMember.java
@@ -17,6 +17,11 @@ public final class CloudBackupSnapshotMember {
      */
     private @Nullable String cloudProvider;
     /**
+     * @return Unique identifier for the sharded cluster snapshot.
+     * 
+     */
+    private @Nullable String id;
+    /**
      * @return Label given to a shard or config server from which Atlas took this snapshot.
      * 
      */
@@ -29,6 +34,13 @@ public final class CloudBackupSnapshotMember {
      */
     public Optional<String> cloudProvider() {
         return Optional.ofNullable(this.cloudProvider);
+    }
+    /**
+     * @return Unique identifier for the sharded cluster snapshot.
+     * 
+     */
+    public Optional<String> id() {
+        return Optional.ofNullable(this.id);
     }
     /**
      * @return Label given to a shard or config server from which Atlas took this snapshot.
@@ -48,17 +60,24 @@ public final class CloudBackupSnapshotMember {
     @CustomType.Builder
     public static final class Builder {
         private @Nullable String cloudProvider;
+        private @Nullable String id;
         private @Nullable String replicaSetName;
         public Builder() {}
         public Builder(CloudBackupSnapshotMember defaults) {
     	      Objects.requireNonNull(defaults);
     	      this.cloudProvider = defaults.cloudProvider;
+    	      this.id = defaults.id;
     	      this.replicaSetName = defaults.replicaSetName;
         }
 
         @CustomType.Setter
         public Builder cloudProvider(@Nullable String cloudProvider) {
             this.cloudProvider = cloudProvider;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(@Nullable String id) {
+            this.id = id;
             return this;
         }
         @CustomType.Setter
@@ -69,6 +88,7 @@ public final class CloudBackupSnapshotMember {
         public CloudBackupSnapshotMember build() {
             final var o = new CloudBackupSnapshotMember();
             o.cloudProvider = cloudProvider;
+            o.id = id;
             o.replicaSetName = replicaSetName;
             return o;
         }

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudProviderSnapshotBackupPolicyPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudProviderSnapshotBackupPolicyPolicy.java
@@ -5,14 +5,19 @@ package com.pulumi.mongodbatlas.outputs;
 
 import com.pulumi.core.annotations.CustomType;
 import com.pulumi.mongodbatlas.outputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItem;
+import java.lang.String;
 import java.util.List;
 import java.util.Objects;
 
 @CustomType
 public final class CloudProviderSnapshotBackupPolicyPolicy {
+    private String id;
     private List<CloudProviderSnapshotBackupPolicyPolicyPolicyItem> policyItems;
 
     private CloudProviderSnapshotBackupPolicyPolicy() {}
+    public String id() {
+        return this.id;
+    }
     public List<CloudProviderSnapshotBackupPolicyPolicyPolicyItem> policyItems() {
         return this.policyItems;
     }
@@ -26,13 +31,20 @@ public final class CloudProviderSnapshotBackupPolicyPolicy {
     }
     @CustomType.Builder
     public static final class Builder {
+        private String id;
         private List<CloudProviderSnapshotBackupPolicyPolicyPolicyItem> policyItems;
         public Builder() {}
         public Builder(CloudProviderSnapshotBackupPolicyPolicy defaults) {
     	      Objects.requireNonNull(defaults);
+    	      this.id = defaults.id;
     	      this.policyItems = defaults.policyItems;
         }
 
+        @CustomType.Setter
+        public Builder id(String id) {
+            this.id = Objects.requireNonNull(id);
+            return this;
+        }
         @CustomType.Setter
         public Builder policyItems(List<CloudProviderSnapshotBackupPolicyPolicyPolicyItem> policyItems) {
             this.policyItems = Objects.requireNonNull(policyItems);
@@ -43,6 +55,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicy {
         }
         public CloudProviderSnapshotBackupPolicyPolicy build() {
             final var o = new CloudProviderSnapshotBackupPolicyPolicy();
+            o.id = id;
             o.policyItems = policyItems;
             return o;
         }

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItem.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/CloudProviderSnapshotBackupPolicyPolicyPolicyItem.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
     private Integer frequencyInterval;
     private String frequencyType;
+    private String id;
     private String retentionUnit;
     private Integer retentionValue;
 
@@ -21,6 +22,9 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
     }
     public String frequencyType() {
         return this.frequencyType;
+    }
+    public String id() {
+        return this.id;
     }
     public String retentionUnit() {
         return this.retentionUnit;
@@ -40,6 +44,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
     public static final class Builder {
         private Integer frequencyInterval;
         private String frequencyType;
+        private String id;
         private String retentionUnit;
         private Integer retentionValue;
         public Builder() {}
@@ -47,6 +52,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
     	      Objects.requireNonNull(defaults);
     	      this.frequencyInterval = defaults.frequencyInterval;
     	      this.frequencyType = defaults.frequencyType;
+    	      this.id = defaults.id;
     	      this.retentionUnit = defaults.retentionUnit;
     	      this.retentionValue = defaults.retentionValue;
         }
@@ -59,6 +65,11 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
         @CustomType.Setter
         public Builder frequencyType(String frequencyType) {
             this.frequencyType = Objects.requireNonNull(frequencyType);
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(String id) {
+            this.id = Objects.requireNonNull(id);
             return this;
         }
         @CustomType.Setter
@@ -75,6 +86,7 @@ public final class CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
             final var o = new CloudProviderSnapshotBackupPolicyPolicyPolicyItem();
             o.frequencyInterval = frequencyInterval;
             o.frequencyType = frequencyType;
+            o.id = id;
             o.retentionUnit = retentionUnit;
             o.retentionValue = retentionValue;
             return o;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/ClusterSnapshotBackupPolicyPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/ClusterSnapshotBackupPolicyPolicy.java
@@ -5,15 +5,29 @@ package com.pulumi.mongodbatlas.outputs;
 
 import com.pulumi.core.annotations.CustomType;
 import com.pulumi.mongodbatlas.outputs.ClusterSnapshotBackupPolicyPolicyPolicyItem;
+import java.lang.String;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 @CustomType
 public final class ClusterSnapshotBackupPolicyPolicy {
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    private @Nullable String id;
     private @Nullable List<ClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems;
 
     private ClusterSnapshotBackupPolicyPolicy() {}
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public Optional<String> id() {
+        return Optional.ofNullable(this.id);
+    }
     public List<ClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems() {
         return this.policyItems == null ? List.of() : this.policyItems;
     }
@@ -27,13 +41,20 @@ public final class ClusterSnapshotBackupPolicyPolicy {
     }
     @CustomType.Builder
     public static final class Builder {
+        private @Nullable String id;
         private @Nullable List<ClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems;
         public Builder() {}
         public Builder(ClusterSnapshotBackupPolicyPolicy defaults) {
     	      Objects.requireNonNull(defaults);
+    	      this.id = defaults.id;
     	      this.policyItems = defaults.policyItems;
         }
 
+        @CustomType.Setter
+        public Builder id(@Nullable String id) {
+            this.id = id;
+            return this;
+        }
         @CustomType.Setter
         public Builder policyItems(@Nullable List<ClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems) {
             this.policyItems = policyItems;
@@ -44,6 +65,7 @@ public final class ClusterSnapshotBackupPolicyPolicy {
         }
         public ClusterSnapshotBackupPolicyPolicy build() {
             final var o = new ClusterSnapshotBackupPolicyPolicy();
+            o.id = id;
             o.policyItems = policyItems;
             return o;
         }

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/ClusterSnapshotBackupPolicyPolicyPolicyItem.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/ClusterSnapshotBackupPolicyPolicyPolicyItem.java
@@ -14,6 +14,11 @@ import javax.annotation.Nullable;
 public final class ClusterSnapshotBackupPolicyPolicyPolicyItem {
     private @Nullable Integer frequencyInterval;
     private @Nullable String frequencyType;
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    private @Nullable String id;
     private @Nullable String retentionUnit;
     private @Nullable Integer retentionValue;
 
@@ -23,6 +28,13 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItem {
     }
     public Optional<String> frequencyType() {
         return Optional.ofNullable(this.frequencyType);
+    }
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public Optional<String> id() {
+        return Optional.ofNullable(this.id);
     }
     public Optional<String> retentionUnit() {
         return Optional.ofNullable(this.retentionUnit);
@@ -42,6 +54,7 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItem {
     public static final class Builder {
         private @Nullable Integer frequencyInterval;
         private @Nullable String frequencyType;
+        private @Nullable String id;
         private @Nullable String retentionUnit;
         private @Nullable Integer retentionValue;
         public Builder() {}
@@ -49,6 +62,7 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItem {
     	      Objects.requireNonNull(defaults);
     	      this.frequencyInterval = defaults.frequencyInterval;
     	      this.frequencyType = defaults.frequencyType;
+    	      this.id = defaults.id;
     	      this.retentionUnit = defaults.retentionUnit;
     	      this.retentionValue = defaults.retentionValue;
         }
@@ -61,6 +75,11 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItem {
         @CustomType.Setter
         public Builder frequencyType(@Nullable String frequencyType) {
             this.frequencyType = frequencyType;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(@Nullable String id) {
+            this.id = id;
             return this;
         }
         @CustomType.Setter
@@ -77,6 +96,7 @@ public final class ClusterSnapshotBackupPolicyPolicyPolicyItem {
             final var o = new ClusterSnapshotBackupPolicyPolicyPolicyItem();
             o.frequencyInterval = frequencyInterval;
             o.frequencyType = frequencyType;
+            o.id = id;
             o.retentionUnit = retentionUnit;
             o.retentionValue = retentionValue;
             return o;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClusterSnapshotBackupPolicyPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClusterSnapshotBackupPolicyPolicy.java
@@ -5,14 +5,27 @@ package com.pulumi.mongodbatlas.outputs;
 
 import com.pulumi.core.annotations.CustomType;
 import com.pulumi.mongodbatlas.outputs.GetClusterSnapshotBackupPolicyPolicyPolicyItem;
+import java.lang.String;
 import java.util.List;
 import java.util.Objects;
 
 @CustomType
 public final class GetClusterSnapshotBackupPolicyPolicy {
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    private String id;
     private List<GetClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems;
 
     private GetClusterSnapshotBackupPolicyPolicy() {}
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public String id() {
+        return this.id;
+    }
     public List<GetClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems() {
         return this.policyItems;
     }
@@ -26,13 +39,20 @@ public final class GetClusterSnapshotBackupPolicyPolicy {
     }
     @CustomType.Builder
     public static final class Builder {
+        private String id;
         private List<GetClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems;
         public Builder() {}
         public Builder(GetClusterSnapshotBackupPolicyPolicy defaults) {
     	      Objects.requireNonNull(defaults);
+    	      this.id = defaults.id;
     	      this.policyItems = defaults.policyItems;
         }
 
+        @CustomType.Setter
+        public Builder id(String id) {
+            this.id = Objects.requireNonNull(id);
+            return this;
+        }
         @CustomType.Setter
         public Builder policyItems(List<GetClusterSnapshotBackupPolicyPolicyPolicyItem> policyItems) {
             this.policyItems = Objects.requireNonNull(policyItems);
@@ -43,6 +63,7 @@ public final class GetClusterSnapshotBackupPolicyPolicy {
         }
         public GetClusterSnapshotBackupPolicyPolicy build() {
             final var o = new GetClusterSnapshotBackupPolicyPolicy();
+            o.id = id;
             o.policyItems = policyItems;
             return o;
         }

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClusterSnapshotBackupPolicyPolicyPolicyItem.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClusterSnapshotBackupPolicyPolicyPolicyItem.java
@@ -12,6 +12,11 @@ import java.util.Objects;
 public final class GetClusterSnapshotBackupPolicyPolicyPolicyItem {
     private Integer frequencyInterval;
     private String frequencyType;
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    private String id;
     private String retentionUnit;
     private Integer retentionValue;
 
@@ -21,6 +26,13 @@ public final class GetClusterSnapshotBackupPolicyPolicyPolicyItem {
     }
     public String frequencyType() {
         return this.frequencyType;
+    }
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public String id() {
+        return this.id;
     }
     public String retentionUnit() {
         return this.retentionUnit;
@@ -40,6 +52,7 @@ public final class GetClusterSnapshotBackupPolicyPolicyPolicyItem {
     public static final class Builder {
         private Integer frequencyInterval;
         private String frequencyType;
+        private String id;
         private String retentionUnit;
         private Integer retentionValue;
         public Builder() {}
@@ -47,6 +60,7 @@ public final class GetClusterSnapshotBackupPolicyPolicyPolicyItem {
     	      Objects.requireNonNull(defaults);
     	      this.frequencyInterval = defaults.frequencyInterval;
     	      this.frequencyType = defaults.frequencyType;
+    	      this.id = defaults.id;
     	      this.retentionUnit = defaults.retentionUnit;
     	      this.retentionValue = defaults.retentionValue;
         }
@@ -59,6 +73,11 @@ public final class GetClusterSnapshotBackupPolicyPolicyPolicyItem {
         @CustomType.Setter
         public Builder frequencyType(String frequencyType) {
             this.frequencyType = Objects.requireNonNull(frequencyType);
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(String id) {
+            this.id = Objects.requireNonNull(id);
             return this;
         }
         @CustomType.Setter
@@ -75,6 +94,7 @@ public final class GetClusterSnapshotBackupPolicyPolicyPolicyItem {
             final var o = new GetClusterSnapshotBackupPolicyPolicyPolicyItem();
             o.frequencyInterval = frequencyInterval;
             o.frequencyType = frequencyType;
+            o.id = id;
             o.retentionUnit = retentionUnit;
             o.retentionValue = retentionValue;
             return o;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClustersResultSnapshotBackupPolicyPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClustersResultSnapshotBackupPolicyPolicy.java
@@ -5,14 +5,27 @@ package com.pulumi.mongodbatlas.outputs;
 
 import com.pulumi.core.annotations.CustomType;
 import com.pulumi.mongodbatlas.outputs.GetClustersResultSnapshotBackupPolicyPolicyPolicyItem;
+import java.lang.String;
 import java.util.List;
 import java.util.Objects;
 
 @CustomType
 public final class GetClustersResultSnapshotBackupPolicyPolicy {
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    private String id;
     private List<GetClustersResultSnapshotBackupPolicyPolicyPolicyItem> policyItems;
 
     private GetClustersResultSnapshotBackupPolicyPolicy() {}
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public String id() {
+        return this.id;
+    }
     public List<GetClustersResultSnapshotBackupPolicyPolicyPolicyItem> policyItems() {
         return this.policyItems;
     }
@@ -26,13 +39,20 @@ public final class GetClustersResultSnapshotBackupPolicyPolicy {
     }
     @CustomType.Builder
     public static final class Builder {
+        private String id;
         private List<GetClustersResultSnapshotBackupPolicyPolicyPolicyItem> policyItems;
         public Builder() {}
         public Builder(GetClustersResultSnapshotBackupPolicyPolicy defaults) {
     	      Objects.requireNonNull(defaults);
+    	      this.id = defaults.id;
     	      this.policyItems = defaults.policyItems;
         }
 
+        @CustomType.Setter
+        public Builder id(String id) {
+            this.id = Objects.requireNonNull(id);
+            return this;
+        }
         @CustomType.Setter
         public Builder policyItems(List<GetClustersResultSnapshotBackupPolicyPolicyPolicyItem> policyItems) {
             this.policyItems = Objects.requireNonNull(policyItems);
@@ -43,6 +63,7 @@ public final class GetClustersResultSnapshotBackupPolicyPolicy {
         }
         public GetClustersResultSnapshotBackupPolicyPolicy build() {
             final var o = new GetClustersResultSnapshotBackupPolicyPolicy();
+            o.id = id;
             o.policyItems = policyItems;
             return o;
         }

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClustersResultSnapshotBackupPolicyPolicyPolicyItem.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/GetClustersResultSnapshotBackupPolicyPolicyPolicyItem.java
@@ -12,6 +12,11 @@ import java.util.Objects;
 public final class GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
     private Integer frequencyInterval;
     private String frequencyType;
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    private String id;
     private String retentionUnit;
     private Integer retentionValue;
 
@@ -21,6 +26,13 @@ public final class GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
     }
     public String frequencyType() {
         return this.frequencyType;
+    }
+    /**
+     * @return Unique identifer of the replication document for a zone in a Global Cluster.
+     * 
+     */
+    public String id() {
+        return this.id;
     }
     public String retentionUnit() {
         return this.retentionUnit;
@@ -40,6 +52,7 @@ public final class GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
     public static final class Builder {
         private Integer frequencyInterval;
         private String frequencyType;
+        private String id;
         private String retentionUnit;
         private Integer retentionValue;
         public Builder() {}
@@ -47,6 +60,7 @@ public final class GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
     	      Objects.requireNonNull(defaults);
     	      this.frequencyInterval = defaults.frequencyInterval;
     	      this.frequencyType = defaults.frequencyType;
+    	      this.id = defaults.id;
     	      this.retentionUnit = defaults.retentionUnit;
     	      this.retentionValue = defaults.retentionValue;
         }
@@ -59,6 +73,11 @@ public final class GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
         @CustomType.Setter
         public Builder frequencyType(String frequencyType) {
             this.frequencyType = Objects.requireNonNull(frequencyType);
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(String id) {
+            this.id = Objects.requireNonNull(id);
             return this;
         }
         @CustomType.Setter
@@ -75,6 +94,7 @@ public final class GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
             final var o = new GetClustersResultSnapshotBackupPolicyPolicyPolicyItem();
             o.frequencyInterval = frequencyInterval;
             o.frequencyType = frequencyType;
+            o.id = id;
             o.retentionUnit = retentionUnit;
             o.retentionValue = retentionValue;
             return o;

--- a/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/X509AuthenticationDatabaseUserCertificate.java
+++ b/sdk/java/src/main/java/com/pulumi/mongodbatlas/outputs/X509AuthenticationDatabaseUserCertificate.java
@@ -4,6 +4,7 @@
 package com.pulumi.mongodbatlas.outputs;
 
 import com.pulumi.core.annotations.CustomType;
+import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -13,6 +14,7 @@ import javax.annotation.Nullable;
 public final class X509AuthenticationDatabaseUserCertificate {
     private @Nullable String createdAt;
     private @Nullable String groupId;
+    private @Nullable Integer id;
     private @Nullable String notAfter;
     private @Nullable String subject;
 
@@ -22,6 +24,9 @@ public final class X509AuthenticationDatabaseUserCertificate {
     }
     public Optional<String> groupId() {
         return Optional.ofNullable(this.groupId);
+    }
+    public Optional<Integer> id() {
+        return Optional.ofNullable(this.id);
     }
     public Optional<String> notAfter() {
         return Optional.ofNullable(this.notAfter);
@@ -41,6 +46,7 @@ public final class X509AuthenticationDatabaseUserCertificate {
     public static final class Builder {
         private @Nullable String createdAt;
         private @Nullable String groupId;
+        private @Nullable Integer id;
         private @Nullable String notAfter;
         private @Nullable String subject;
         public Builder() {}
@@ -48,6 +54,7 @@ public final class X509AuthenticationDatabaseUserCertificate {
     	      Objects.requireNonNull(defaults);
     	      this.createdAt = defaults.createdAt;
     	      this.groupId = defaults.groupId;
+    	      this.id = defaults.id;
     	      this.notAfter = defaults.notAfter;
     	      this.subject = defaults.subject;
         }
@@ -60,6 +67,11 @@ public final class X509AuthenticationDatabaseUserCertificate {
         @CustomType.Setter
         public Builder groupId(@Nullable String groupId) {
             this.groupId = groupId;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder id(@Nullable Integer id) {
+            this.id = id;
             return this;
         }
         @CustomType.Setter
@@ -76,6 +88,7 @@ public final class X509AuthenticationDatabaseUserCertificate {
             final var o = new X509AuthenticationDatabaseUserCertificate();
             o.createdAt = createdAt;
             o.groupId = groupId;
+            o.id = id;
             o.notAfter = notAfter;
             o.subject = subject;
             return o;

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -106,6 +106,7 @@ export interface AdvancedClusterReplicationSpec {
      * A key-value map of the Network Peering Container ID(s) for the configuration specified in `regionConfigs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.  The syntax is `"providerName:regionName" = "containerId"`. Example `AWS:US_EAST_1" = "61e0797dde08fb498ca11a71`.
      */
     containerId?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    id?: pulumi.Input<string>;
     /**
      * Provide this value if you set a `clusterType` of SHARDED or GEOSHARDED. Omit this value if you selected a `clusterType` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `numShards` value of 1 and a `clusterType` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
      */
@@ -459,6 +460,7 @@ export interface CloudBackupSchedulePolicyItemDaily {
      * Frequency associated with the export snapshot item.
      */
     frequencyType?: pulumi.Input<string>;
+    id?: pulumi.Input<string>;
     /**
      * Scope of the backup policy item: days, weeks, or months.
      */
@@ -498,6 +500,7 @@ export interface CloudBackupSchedulePolicyItemMonthly {
      * Frequency associated with the export snapshot item.
      */
     frequencyType?: pulumi.Input<string>;
+    id?: pulumi.Input<string>;
     /**
      * Scope of the backup policy item: days, weeks, or months.
      */
@@ -517,6 +520,7 @@ export interface CloudBackupSchedulePolicyItemWeekly {
      * Frequency associated with the export snapshot item.
      */
     frequencyType?: pulumi.Input<string>;
+    id?: pulumi.Input<string>;
     /**
      * Scope of the backup policy item: days, weeks, or months.
      */
@@ -554,6 +558,10 @@ export interface CloudBackupSnapshotMember {
      * Cloud provider that stores this snapshot.
      */
     cloudProvider?: pulumi.Input<string>;
+    /**
+     * Unique identifier for the sharded cluster snapshot.
+     */
+    id?: pulumi.Input<string>;
     /**
      * Label given to a shard or config server from which Atlas took this snapshot.
      */
@@ -597,12 +605,14 @@ export interface CloudProviderAccessSetupAwsConfig {
 }
 
 export interface CloudProviderSnapshotBackupPolicyPolicy {
+    id: pulumi.Input<string>;
     policyItems: pulumi.Input<pulumi.Input<inputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItem>[]>;
 }
 
 export interface CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
     frequencyInterval: pulumi.Input<number>;
     frequencyType: pulumi.Input<string>;
+    id: pulumi.Input<string>;
     retentionUnit: pulumi.Input<string>;
     retentionValue: pulumi.Input<number>;
 }
@@ -783,12 +793,20 @@ export interface ClusterSnapshotBackupPolicy {
 }
 
 export interface ClusterSnapshotBackupPolicyPolicy {
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id?: pulumi.Input<string>;
     policyItems?: pulumi.Input<pulumi.Input<inputs.ClusterSnapshotBackupPolicyPolicyPolicyItem>[]>;
 }
 
 export interface ClusterSnapshotBackupPolicyPolicyPolicyItem {
     frequencyInterval?: pulumi.Input<number>;
     frequencyType?: pulumi.Input<string>;
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id?: pulumi.Input<string>;
     retentionUnit?: pulumi.Input<string>;
     retentionValue?: pulumi.Input<number>;
 }
@@ -1242,6 +1260,7 @@ export interface ServerlessInstanceLink {
 export interface X509AuthenticationDatabaseUserCertificate {
     createdAt?: pulumi.Input<string>;
     groupId?: pulumi.Input<string>;
+    id?: pulumi.Input<number>;
     notAfter?: pulumi.Input<string>;
     subject?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -106,6 +106,7 @@ export interface AdvancedClusterReplicationSpec {
      * A key-value map of the Network Peering Container ID(s) for the configuration specified in `regionConfigs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.  The syntax is `"providerName:regionName" = "containerId"`. Example `AWS:US_EAST_1" = "61e0797dde08fb498ca11a71`.
      */
     containerId: {[key: string]: string};
+    id: string;
     /**
      * Provide this value if you set a `clusterType` of SHARDED or GEOSHARDED. Omit this value if you selected a `clusterType` of REPLICASET. This API resource accepts 1 through 50, inclusive. This parameter defaults to 1. If you specify a `numShards` value of 1 and a `clusterType` of SHARDED, Atlas deploys a single-shard [sharded cluster](https://docs.atlas.mongodb.com/reference/glossary/#std-term-sharded-cluster). Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
      */
@@ -459,6 +460,7 @@ export interface CloudBackupSchedulePolicyItemDaily {
      * Frequency associated with the export snapshot item.
      */
     frequencyType: string;
+    id: string;
     /**
      * Scope of the backup policy item: days, weeks, or months.
      */
@@ -498,6 +500,7 @@ export interface CloudBackupSchedulePolicyItemMonthly {
      * Frequency associated with the export snapshot item.
      */
     frequencyType: string;
+    id: string;
     /**
      * Scope of the backup policy item: days, weeks, or months.
      */
@@ -517,6 +520,7 @@ export interface CloudBackupSchedulePolicyItemWeekly {
      * Frequency associated with the export snapshot item.
      */
     frequencyType: string;
+    id: string;
     /**
      * Scope of the backup policy item: days, weeks, or months.
      */
@@ -554,6 +558,10 @@ export interface CloudBackupSnapshotMember {
      * Cloud provider that stores this snapshot.
      */
     cloudProvider: string;
+    /**
+     * Unique identifier for the sharded cluster snapshot.
+     */
+    id: string;
     /**
      * Label given to a shard or config server from which Atlas took this snapshot.
      */
@@ -597,12 +605,14 @@ export interface CloudProviderAccessSetupAwsConfig {
 }
 
 export interface CloudProviderSnapshotBackupPolicyPolicy {
+    id: string;
     policyItems: outputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItem[];
 }
 
 export interface CloudProviderSnapshotBackupPolicyPolicyPolicyItem {
     frequencyInterval: number;
     frequencyType: string;
+    id: string;
     retentionUnit: string;
     retentionValue: number;
 }
@@ -783,12 +793,20 @@ export interface ClusterSnapshotBackupPolicy {
 }
 
 export interface ClusterSnapshotBackupPolicyPolicy {
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id: string;
     policyItems: outputs.ClusterSnapshotBackupPolicyPolicyPolicyItem[];
 }
 
 export interface ClusterSnapshotBackupPolicyPolicyPolicyItem {
     frequencyInterval: number;
     frequencyType: string;
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id: string;
     retentionUnit: string;
     retentionValue: number;
 }
@@ -2427,12 +2445,20 @@ export interface GetClusterSnapshotBackupPolicy {
 }
 
 export interface GetClusterSnapshotBackupPolicyPolicy {
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id: string;
     policyItems: outputs.GetClusterSnapshotBackupPolicyPolicyPolicyItem[];
 }
 
 export interface GetClusterSnapshotBackupPolicyPolicyPolicyItem {
     frequencyInterval: number;
     frequencyType: string;
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id: string;
     retentionUnit: string;
     retentionValue: number;
 }
@@ -2755,12 +2781,20 @@ export interface GetClustersResultSnapshotBackupPolicy {
 }
 
 export interface GetClustersResultSnapshotBackupPolicyPolicy {
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id: string;
     policyItems: outputs.GetClustersResultSnapshotBackupPolicyPolicyPolicyItem[];
 }
 
 export interface GetClustersResultSnapshotBackupPolicyPolicyPolicyItem {
     frequencyInterval: number;
     frequencyType: string;
+    /**
+     * Unique identifer of the replication document for a zone in a Global Cluster.
+     */
+    id: string;
     retentionUnit: string;
     retentionValue: number;
 }
@@ -4307,6 +4341,7 @@ export interface ServerlessInstanceLink {
 export interface X509AuthenticationDatabaseUserCertificate {
     createdAt: string;
     groupId: string;
+    id: number;
     notAfter: string;
     subject: string;
 }

--- a/sdk/python/pulumi_mongodbatlas/_inputs.py
+++ b/sdk/python/pulumi_mongodbatlas/_inputs.py
@@ -527,6 +527,7 @@ class AdvancedClusterReplicationSpecArgs:
     def __init__(__self__, *,
                  region_configs: pulumi.Input[Sequence[pulumi.Input['AdvancedClusterReplicationSpecRegionConfigArgs']]],
                  container_id: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 id: Optional[pulumi.Input[str]] = None,
                  num_shards: Optional[pulumi.Input[int]] = None,
                  zone_name: Optional[pulumi.Input[str]] = None):
         """
@@ -538,6 +539,8 @@ class AdvancedClusterReplicationSpecArgs:
         pulumi.set(__self__, "region_configs", region_configs)
         if container_id is not None:
             pulumi.set(__self__, "container_id", container_id)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if num_shards is not None:
             pulumi.set(__self__, "num_shards", num_shards)
         if zone_name is not None:
@@ -566,6 +569,15 @@ class AdvancedClusterReplicationSpecArgs:
     @container_id.setter
     def container_id(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "container_id", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "id", value)
 
     @property
     @pulumi.getter(name="numShards")
@@ -1750,7 +1762,8 @@ class CloudBackupSchedulePolicyItemDailyArgs:
                  frequency_interval: pulumi.Input[int],
                  retention_unit: pulumi.Input[str],
                  retention_value: pulumi.Input[int],
-                 frequency_type: Optional[pulumi.Input[str]] = None):
+                 frequency_type: Optional[pulumi.Input[str]] = None,
+                 id: Optional[pulumi.Input[str]] = None):
         """
         :param pulumi.Input[int] frequency_interval: Desired frequency of the new backup policy item specified by `frequency_type`.
         :param pulumi.Input[str] retention_unit: Scope of the backup policy item: days, weeks, or months.
@@ -1762,6 +1775,8 @@ class CloudBackupSchedulePolicyItemDailyArgs:
         pulumi.set(__self__, "retention_value", retention_value)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
 
     @property
     @pulumi.getter(name="frequencyInterval")
@@ -1810,6 +1825,15 @@ class CloudBackupSchedulePolicyItemDailyArgs:
     @frequency_type.setter
     def frequency_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "frequency_type", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "id", value)
 
 
 @pulumi.input_type
@@ -1898,7 +1922,8 @@ class CloudBackupSchedulePolicyItemMonthlyArgs:
                  frequency_interval: pulumi.Input[int],
                  retention_unit: pulumi.Input[str],
                  retention_value: pulumi.Input[int],
-                 frequency_type: Optional[pulumi.Input[str]] = None):
+                 frequency_type: Optional[pulumi.Input[str]] = None,
+                 id: Optional[pulumi.Input[str]] = None):
         """
         :param pulumi.Input[int] frequency_interval: Desired frequency of the new backup policy item specified by `frequency_type`.
         :param pulumi.Input[str] retention_unit: Scope of the backup policy item: days, weeks, or months.
@@ -1910,6 +1935,8 @@ class CloudBackupSchedulePolicyItemMonthlyArgs:
         pulumi.set(__self__, "retention_value", retention_value)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
 
     @property
     @pulumi.getter(name="frequencyInterval")
@@ -1958,6 +1985,15 @@ class CloudBackupSchedulePolicyItemMonthlyArgs:
     @frequency_type.setter
     def frequency_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "frequency_type", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "id", value)
 
 
 @pulumi.input_type
@@ -1966,7 +2002,8 @@ class CloudBackupSchedulePolicyItemWeeklyArgs:
                  frequency_interval: pulumi.Input[int],
                  retention_unit: pulumi.Input[str],
                  retention_value: pulumi.Input[int],
-                 frequency_type: Optional[pulumi.Input[str]] = None):
+                 frequency_type: Optional[pulumi.Input[str]] = None,
+                 id: Optional[pulumi.Input[str]] = None):
         """
         :param pulumi.Input[int] frequency_interval: Desired frequency of the new backup policy item specified by `frequency_type`.
         :param pulumi.Input[str] retention_unit: Scope of the backup policy item: days, weeks, or months.
@@ -1978,6 +2015,8 @@ class CloudBackupSchedulePolicyItemWeeklyArgs:
         pulumi.set(__self__, "retention_value", retention_value)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
 
     @property
     @pulumi.getter(name="frequencyInterval")
@@ -2026,6 +2065,15 @@ class CloudBackupSchedulePolicyItemWeeklyArgs:
     @frequency_type.setter
     def frequency_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "frequency_type", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "id", value)
 
 
 @pulumi.input_type
@@ -2108,13 +2156,17 @@ class CloudBackupSnapshotExportJobCustomDataArgs:
 class CloudBackupSnapshotMemberArgs:
     def __init__(__self__, *,
                  cloud_provider: Optional[pulumi.Input[str]] = None,
+                 id: Optional[pulumi.Input[str]] = None,
                  replica_set_name: Optional[pulumi.Input[str]] = None):
         """
         :param pulumi.Input[str] cloud_provider: Cloud provider that stores this snapshot.
+        :param pulumi.Input[str] id: Unique identifier for the sharded cluster snapshot.
         :param pulumi.Input[str] replica_set_name: Label given to a shard or config server from which Atlas took this snapshot.
         """
         if cloud_provider is not None:
             pulumi.set(__self__, "cloud_provider", cloud_provider)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if replica_set_name is not None:
             pulumi.set(__self__, "replica_set_name", replica_set_name)
 
@@ -2129,6 +2181,18 @@ class CloudBackupSnapshotMemberArgs:
     @cloud_provider.setter
     def cloud_provider(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "cloud_provider", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[str]]:
+        """
+        Unique identifier for the sharded cluster snapshot.
+        """
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "id", value)
 
     @property
     @pulumi.getter(name="replicaSetName")
@@ -2360,8 +2424,19 @@ class CloudProviderAccessSetupAwsConfigArgs:
 @pulumi.input_type
 class CloudProviderSnapshotBackupPolicyPolicyArgs:
     def __init__(__self__, *,
+                 id: pulumi.Input[str],
                  policy_items: pulumi.Input[Sequence[pulumi.Input['CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs']]]):
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "policy_items", policy_items)
+
+    @property
+    @pulumi.getter
+    def id(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: pulumi.Input[str]):
+        pulumi.set(self, "id", value)
 
     @property
     @pulumi.getter(name="policyItems")
@@ -2378,10 +2453,12 @@ class CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs:
     def __init__(__self__, *,
                  frequency_interval: pulumi.Input[int],
                  frequency_type: pulumi.Input[str],
+                 id: pulumi.Input[str],
                  retention_unit: pulumi.Input[str],
                  retention_value: pulumi.Input[int]):
         pulumi.set(__self__, "frequency_interval", frequency_interval)
         pulumi.set(__self__, "frequency_type", frequency_type)
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "retention_unit", retention_unit)
         pulumi.set(__self__, "retention_value", retention_value)
 
@@ -2402,6 +2479,15 @@ class CloudProviderSnapshotBackupPolicyPolicyPolicyItemArgs:
     @frequency_type.setter
     def frequency_type(self, value: pulumi.Input[str]):
         pulumi.set(self, "frequency_type", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: pulumi.Input[str]):
+        pulumi.set(self, "id", value)
 
     @property
     @pulumi.getter(name="retentionUnit")
@@ -3241,9 +3327,27 @@ class ClusterSnapshotBackupPolicyArgs:
 @pulumi.input_type
 class ClusterSnapshotBackupPolicyPolicyArgs:
     def __init__(__self__, *,
+                 id: Optional[pulumi.Input[str]] = None,
                  policy_items: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterSnapshotBackupPolicyPolicyPolicyItemArgs']]]] = None):
+        """
+        :param pulumi.Input[str] id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if policy_items is not None:
             pulumi.set(__self__, "policy_items", policy_items)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[str]]:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "id", value)
 
     @property
     @pulumi.getter(name="policyItems")
@@ -3260,12 +3364,18 @@ class ClusterSnapshotBackupPolicyPolicyPolicyItemArgs:
     def __init__(__self__, *,
                  frequency_interval: Optional[pulumi.Input[int]] = None,
                  frequency_type: Optional[pulumi.Input[str]] = None,
+                 id: Optional[pulumi.Input[str]] = None,
                  retention_unit: Optional[pulumi.Input[str]] = None,
                  retention_value: Optional[pulumi.Input[int]] = None):
+        """
+        :param pulumi.Input[str] id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
         if frequency_interval is not None:
             pulumi.set(__self__, "frequency_interval", frequency_interval)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if retention_unit is not None:
             pulumi.set(__self__, "retention_unit", retention_unit)
         if retention_value is not None:
@@ -3288,6 +3398,18 @@ class ClusterSnapshotBackupPolicyPolicyPolicyItemArgs:
     @frequency_type.setter
     def frequency_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "frequency_type", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[str]]:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "id", value)
 
     @property
     @pulumi.getter(name="retentionUnit")
@@ -4942,12 +5064,15 @@ class X509AuthenticationDatabaseUserCertificateArgs:
     def __init__(__self__, *,
                  created_at: Optional[pulumi.Input[str]] = None,
                  group_id: Optional[pulumi.Input[str]] = None,
+                 id: Optional[pulumi.Input[int]] = None,
                  not_after: Optional[pulumi.Input[str]] = None,
                  subject: Optional[pulumi.Input[str]] = None):
         if created_at is not None:
             pulumi.set(__self__, "created_at", created_at)
         if group_id is not None:
             pulumi.set(__self__, "group_id", group_id)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if not_after is not None:
             pulumi.set(__self__, "not_after", not_after)
         if subject is not None:
@@ -4970,6 +5095,15 @@ class X509AuthenticationDatabaseUserCertificateArgs:
     @group_id.setter
     def group_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "group_id", value)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[pulumi.Input[int]]:
+        return pulumi.get(self, "id")
+
+    @id.setter
+    def id(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "id", value)
 
     @property
     @pulumi.getter(name="notAfter")

--- a/sdk/python/pulumi_mongodbatlas/outputs.py
+++ b/sdk/python/pulumi_mongodbatlas/outputs.py
@@ -705,6 +705,7 @@ class AdvancedClusterReplicationSpec(dict):
     def __init__(__self__, *,
                  region_configs: Sequence['outputs.AdvancedClusterReplicationSpecRegionConfig'],
                  container_id: Optional[Mapping[str, str]] = None,
+                 id: Optional[str] = None,
                  num_shards: Optional[int] = None,
                  zone_name: Optional[str] = None):
         """
@@ -716,6 +717,8 @@ class AdvancedClusterReplicationSpec(dict):
         pulumi.set(__self__, "region_configs", region_configs)
         if container_id is not None:
             pulumi.set(__self__, "container_id", container_id)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if num_shards is not None:
             pulumi.set(__self__, "num_shards", num_shards)
         if zone_name is not None:
@@ -736,6 +739,11 @@ class AdvancedClusterReplicationSpec(dict):
         A key-value map of the Network Peering Container ID(s) for the configuration specified in `region_configs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.  The syntax is `"providerName:regionName" = "containerId"`. Example `AWS:US_EAST_1" = "61e0797dde08fb498ca11a71`.
         """
         return pulumi.get(self, "container_id")
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[str]:
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="numShards")
@@ -1924,7 +1932,8 @@ class CloudBackupSchedulePolicyItemDaily(dict):
                  frequency_interval: int,
                  retention_unit: str,
                  retention_value: int,
-                 frequency_type: Optional[str] = None):
+                 frequency_type: Optional[str] = None,
+                 id: Optional[str] = None):
         """
         :param int frequency_interval: Desired frequency of the new backup policy item specified by `frequency_type`.
         :param str retention_unit: Scope of the backup policy item: days, weeks, or months.
@@ -1936,6 +1945,8 @@ class CloudBackupSchedulePolicyItemDaily(dict):
         pulumi.set(__self__, "retention_value", retention_value)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
 
     @property
     @pulumi.getter(name="frequencyInterval")
@@ -1968,6 +1979,11 @@ class CloudBackupSchedulePolicyItemDaily(dict):
         Frequency associated with the export snapshot item.
         """
         return pulumi.get(self, "frequency_type")
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[str]:
+        return pulumi.get(self, "id")
 
 
 @pulumi.output_type
@@ -2082,7 +2098,8 @@ class CloudBackupSchedulePolicyItemMonthly(dict):
                  frequency_interval: int,
                  retention_unit: str,
                  retention_value: int,
-                 frequency_type: Optional[str] = None):
+                 frequency_type: Optional[str] = None,
+                 id: Optional[str] = None):
         """
         :param int frequency_interval: Desired frequency of the new backup policy item specified by `frequency_type`.
         :param str retention_unit: Scope of the backup policy item: days, weeks, or months.
@@ -2094,6 +2111,8 @@ class CloudBackupSchedulePolicyItemMonthly(dict):
         pulumi.set(__self__, "retention_value", retention_value)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
 
     @property
     @pulumi.getter(name="frequencyInterval")
@@ -2126,6 +2145,11 @@ class CloudBackupSchedulePolicyItemMonthly(dict):
         Frequency associated with the export snapshot item.
         """
         return pulumi.get(self, "frequency_type")
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[str]:
+        return pulumi.get(self, "id")
 
 
 @pulumi.output_type
@@ -2157,7 +2181,8 @@ class CloudBackupSchedulePolicyItemWeekly(dict):
                  frequency_interval: int,
                  retention_unit: str,
                  retention_value: int,
-                 frequency_type: Optional[str] = None):
+                 frequency_type: Optional[str] = None,
+                 id: Optional[str] = None):
         """
         :param int frequency_interval: Desired frequency of the new backup policy item specified by `frequency_type`.
         :param str retention_unit: Scope of the backup policy item: days, weeks, or months.
@@ -2169,6 +2194,8 @@ class CloudBackupSchedulePolicyItemWeekly(dict):
         pulumi.set(__self__, "retention_value", retention_value)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
 
     @property
     @pulumi.getter(name="frequencyInterval")
@@ -2201,6 +2228,11 @@ class CloudBackupSchedulePolicyItemWeekly(dict):
         Frequency associated with the export snapshot item.
         """
         return pulumi.get(self, "frequency_type")
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[str]:
+        return pulumi.get(self, "id")
 
 
 @pulumi.output_type
@@ -2305,13 +2337,17 @@ class CloudBackupSnapshotMember(dict):
 
     def __init__(__self__, *,
                  cloud_provider: Optional[str] = None,
+                 id: Optional[str] = None,
                  replica_set_name: Optional[str] = None):
         """
         :param str cloud_provider: Cloud provider that stores this snapshot.
+        :param str id: Unique identifier for the sharded cluster snapshot.
         :param str replica_set_name: Label given to a shard or config server from which Atlas took this snapshot.
         """
         if cloud_provider is not None:
             pulumi.set(__self__, "cloud_provider", cloud_provider)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if replica_set_name is not None:
             pulumi.set(__self__, "replica_set_name", replica_set_name)
 
@@ -2322,6 +2358,14 @@ class CloudBackupSnapshotMember(dict):
         Cloud provider that stores this snapshot.
         """
         return pulumi.get(self, "cloud_provider")
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[str]:
+        """
+        Unique identifier for the sharded cluster snapshot.
+        """
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="replicaSetName")
@@ -2607,8 +2651,15 @@ class CloudProviderSnapshotBackupPolicyPolicy(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
+                 id: str,
                  policy_items: Sequence['outputs.CloudProviderSnapshotBackupPolicyPolicyPolicyItem']):
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "policy_items", policy_items)
+
+    @property
+    @pulumi.getter
+    def id(self) -> str:
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="policyItems")
@@ -2644,10 +2695,12 @@ class CloudProviderSnapshotBackupPolicyPolicyPolicyItem(dict):
     def __init__(__self__, *,
                  frequency_interval: int,
                  frequency_type: str,
+                 id: str,
                  retention_unit: str,
                  retention_value: int):
         pulumi.set(__self__, "frequency_interval", frequency_interval)
         pulumi.set(__self__, "frequency_type", frequency_type)
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "retention_unit", retention_unit)
         pulumi.set(__self__, "retention_value", retention_value)
 
@@ -2660,6 +2713,11 @@ class CloudProviderSnapshotBackupPolicyPolicyPolicyItem(dict):
     @pulumi.getter(name="frequencyType")
     def frequency_type(self) -> str:
         return pulumi.get(self, "frequency_type")
+
+    @property
+    @pulumi.getter
+    def id(self) -> str:
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="retentionUnit")
@@ -3507,9 +3565,23 @@ class ClusterSnapshotBackupPolicyPolicy(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
+                 id: Optional[str] = None,
                  policy_items: Optional[Sequence['outputs.ClusterSnapshotBackupPolicyPolicyPolicyItem']] = None):
+        """
+        :param str id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if policy_items is not None:
             pulumi.set(__self__, "policy_items", policy_items)
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[str]:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="policyItems")
@@ -3545,12 +3617,18 @@ class ClusterSnapshotBackupPolicyPolicyPolicyItem(dict):
     def __init__(__self__, *,
                  frequency_interval: Optional[int] = None,
                  frequency_type: Optional[str] = None,
+                 id: Optional[str] = None,
                  retention_unit: Optional[str] = None,
                  retention_value: Optional[int] = None):
+        """
+        :param str id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
         if frequency_interval is not None:
             pulumi.set(__self__, "frequency_interval", frequency_interval)
         if frequency_type is not None:
             pulumi.set(__self__, "frequency_type", frequency_type)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if retention_unit is not None:
             pulumi.set(__self__, "retention_unit", retention_unit)
         if retention_value is not None:
@@ -3565,6 +3643,14 @@ class ClusterSnapshotBackupPolicyPolicyPolicyItem(dict):
     @pulumi.getter(name="frequencyType")
     def frequency_type(self) -> Optional[str]:
         return pulumi.get(self, "frequency_type")
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[str]:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="retentionUnit")
@@ -5302,12 +5388,15 @@ class X509AuthenticationDatabaseUserCertificate(dict):
     def __init__(__self__, *,
                  created_at: Optional[str] = None,
                  group_id: Optional[str] = None,
+                 id: Optional[int] = None,
                  not_after: Optional[str] = None,
                  subject: Optional[str] = None):
         if created_at is not None:
             pulumi.set(__self__, "created_at", created_at)
         if group_id is not None:
             pulumi.set(__self__, "group_id", group_id)
+        if id is not None:
+            pulumi.set(__self__, "id", id)
         if not_after is not None:
             pulumi.set(__self__, "not_after", not_after)
         if subject is not None:
@@ -5322,6 +5411,11 @@ class X509AuthenticationDatabaseUserCertificate(dict):
     @pulumi.getter(name="groupId")
     def group_id(self) -> Optional[str]:
         return pulumi.get(self, "group_id")
+
+    @property
+    @pulumi.getter
+    def id(self) -> Optional[int]:
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="notAfter")
@@ -9357,8 +9451,21 @@ class GetClusterSnapshotBackupPolicyResult(dict):
 @pulumi.output_type
 class GetClusterSnapshotBackupPolicyPolicyResult(dict):
     def __init__(__self__, *,
+                 id: str,
                  policy_items: Sequence['outputs.GetClusterSnapshotBackupPolicyPolicyPolicyItemResult']):
+        """
+        :param str id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "policy_items", policy_items)
+
+    @property
+    @pulumi.getter
+    def id(self) -> str:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="policyItems")
@@ -9371,10 +9478,15 @@ class GetClusterSnapshotBackupPolicyPolicyPolicyItemResult(dict):
     def __init__(__self__, *,
                  frequency_interval: int,
                  frequency_type: str,
+                 id: str,
                  retention_unit: str,
                  retention_value: int):
+        """
+        :param str id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
         pulumi.set(__self__, "frequency_interval", frequency_interval)
         pulumi.set(__self__, "frequency_type", frequency_type)
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "retention_unit", retention_unit)
         pulumi.set(__self__, "retention_value", retention_value)
 
@@ -9387,6 +9499,14 @@ class GetClusterSnapshotBackupPolicyPolicyPolicyItemResult(dict):
     @pulumi.getter(name="frequencyType")
     def frequency_type(self) -> str:
         return pulumi.get(self, "frequency_type")
+
+    @property
+    @pulumi.getter
+    def id(self) -> str:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="retentionUnit")
@@ -10329,8 +10449,21 @@ class GetClustersResultSnapshotBackupPolicyResult(dict):
 @pulumi.output_type
 class GetClustersResultSnapshotBackupPolicyPolicyResult(dict):
     def __init__(__self__, *,
+                 id: str,
                  policy_items: Sequence['outputs.GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult']):
+        """
+        :param str id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "policy_items", policy_items)
+
+    @property
+    @pulumi.getter
+    def id(self) -> str:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="policyItems")
@@ -10343,10 +10476,15 @@ class GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult(dict):
     def __init__(__self__, *,
                  frequency_interval: int,
                  frequency_type: str,
+                 id: str,
                  retention_unit: str,
                  retention_value: int):
+        """
+        :param str id: Unique identifer of the replication document for a zone in a Global Cluster.
+        """
         pulumi.set(__self__, "frequency_interval", frequency_interval)
         pulumi.set(__self__, "frequency_type", frequency_type)
+        pulumi.set(__self__, "id", id)
         pulumi.set(__self__, "retention_unit", retention_unit)
         pulumi.set(__self__, "retention_value", retention_value)
 
@@ -10359,6 +10497,14 @@ class GetClustersResultSnapshotBackupPolicyPolicyPolicyItemResult(dict):
     @pulumi.getter(name="frequencyType")
     def frequency_type(self) -> str:
         return pulumi.get(self, "frequency_type")
+
+    @property
+    @pulumi.getter
+    def id(self) -> str:
+        """
+        Unique identifer of the replication document for a zone in a Global Cluster.
+        """
+        return pulumi.get(self, "id")
 
     @property
     @pulumi.getter(name="retentionUnit")


### PR DESCRIPTION
Fixes #126

Note that we still need to maintain our fork due to the [fact that Pulumi aslo uses environment variables](https://github.com/pulumi/terraform-provider-mongodbatlas/commit/10ffe276672c978f72c9f1f9133a6874e1d1a314)

This is based on the [upstream-v1.4.5-id-fix branch of pulumi/terraform-provider-mongodbatlas](https://github.com/pulumi/terraform-provider-mongodbatlas/tree/upstream-v1.4.5-id-fix)

- Pull in updated fork with re-added ID fields
- Build SDKs
