### PR TITLE
Remove upstream fork

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -2,13 +2,10 @@ module github.com/pulumi/pulumi-mongodbatlas/provider/v3
 
 go 1.18
 
-replace (
-	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9
-	github.com/mongodb/terraform-provider-mongodbatlas => github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20230124211744-6052f49210f8
-)
+replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9
 
 require (
-	github.com/mongodb/terraform-provider-mongodbatlas v1.4.6
+	github.com/mongodb/terraform-provider-mongodbatlas v1.7.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.38.1
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1334,6 +1334,8 @@ github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3P
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mongodb-forks/digest v1.0.4 h1:9FrGTc7MGAchgaQBcXBnEwUM/Oo8obW7OGWxnsSvZ64=
 github.com/mongodb-forks/digest v1.0.4/go.mod h1:eHRfgovT+dvSFfltrOa27hy1oR/rcwyDdp5H1ZQxEMA=
+github.com/mongodb/terraform-provider-mongodbatlas v1.7.0 h1:Xh7ogqdwemD5TjXYMX551U2VFBXJgyoTISlW1bvs/00=
+github.com/mongodb/terraform-provider-mongodbatlas v1.7.0/go.mod h1:oYeZm3Q6YXG9gJwaXOVrxICXH/p7Zm65mD70XS4o3vc=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
@@ -1544,8 +1546,6 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9 h1:JMw+t5I+6E8Lna7JF+ghAoOLOl23UIbshJyRNP+K1HU=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9/go.mod h1:mYPs/uchNcBq7AclQv9QUtSf9iNcfp1Ag21jqTlDf2M=
-github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20230124211744-6052f49210f8 h1:TD9ZEbDZCgzA1w0PcrOsm0nPrW7ipo2pArGG2qS7NoA=
-github.com/pulumi/terraform-provider-mongodbatlas v0.5.1-0.20230124211744-6052f49210f8/go.mod h1:oYeZm3Q6YXG9gJwaXOVrxICXH/p7Zm65mD70XS4o3vc=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -59,6 +59,7 @@ func Provider() tfbridge.ProviderInfo {
 	// Instantiate the Terraform provider
 	p := shimv2.NewProvider(mongodbatlas.Provider())
 
+	trueValue := true
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{
 		P:           p,
@@ -69,7 +70,10 @@ func Provider() tfbridge.ProviderInfo {
 		Homepage:    "https://pulumi.io",
 		Repository:  "https://github.com/pulumi/pulumi-mongodbatlas",
 		GitHubOrg:   "mongodb",
-		Config:      map[string]*tfbridge.SchemaInfo{},
+		Config: map[string]*tfbridge.SchemaInfo{
+			"private_key": {MarkAsOptional: &trueValue},
+			"public_key":  {MarkAsOptional: &trueValue},
+		},
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"mongodbatlas_custom_db_role": {Tok: makeResource(mainMod, "CustomDbRole")},
 			"mongodbatlas_custom_dns_configuration_cluster_aws": {


### PR DESCRIPTION
This is a no-op change.

You can see the diff we are maintaining at
https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.7.0...pulumi:terraform-provider-mongodbatlas:upstream-v1.7.0#. We can drop the fork and simplify future releases.