### PR TITLE
Enable zero default schema version for mongodbatlas

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -148,6 +148,7 @@ func Provider() tfbridge.ProviderInfo {
 				"Pulumi": "3.*",
 			},
 		},
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	prov.MustComputeTokens(tks.SingleModule("mongodbatlas_", mainMod,


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133

Enables zero default schema version for mongodbatlas.