### PR TITLE
enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -157,6 +157,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	prov.MustComputeTokens(tks.SingleModule("mongodbatlas_", mainMod,


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the pulumi-mongodbatlas provider. This should improve the quality of our previews for the provider.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2598